### PR TITLE
Make coz use Python 2 explicitly

### DIFF
--- a/coz
+++ b/coz
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import copy


### PR DESCRIPTION
Currently, the script will fail with the following error when the system default python is Python 3:
```
  File "/usr/bin/coz", line 32
    print 'error: specify a command to profile after `---`\n'
                                                            ^
SyntaxError: Missing parentheses in call to 'print'
```