### PR TITLE
Don't force LD_PRELOAD if not given

### DIFF
--- a/coz
+++ b/coz
@@ -39,8 +39,6 @@ def _coz_run(args):
 
   if 'LD_PRELOAD' in env:
     env['LD_PRELOAD'] += ':' + coz_runtime
-  else:
-    env['LD_PRELOAD'] = coz_runtime
 
   if len(args.binary_scope) > 0:
     env['COZ_BINARY_SCOPE'] = '\t'.join(args.binary_scope)


### PR DESCRIPTION
The lack of an `LD_PRELOAD` should imply that `libcoz.so` can be located in standard library directories (e.g. `/usr/lib`), which do not need `LD_PRELOAD` to be specified. Fixes #19.