### PR TITLE
Fix build with g++-4.8

### DIFF
--- a/benchmarks/toy/Makefile
+++ b/benchmarks/toy/Makefile
@@ -2,6 +2,7 @@ ROOT     := ../..
 TARGETS  := toy
 LIBS     := dl pthread
 CXXFLAGS := --std=c++11 -g -O2
+LDFLAGS  := -pthread
 
 ifeq ($(USE_SYSTEM_COZ),)
 CFLAGS += -I$(ROOT)/include

--- a/common.mk
+++ b/common.mk
@@ -1,6 +1,6 @@
 # Build with clang
-CC  := clang
-CXX := clang++
+CC  ?= clang
+CXX ?= clang++
 
 # Set coz and include path for coz
 ifeq ($(USE_SYSTEM_COZ),1)

--- a/common.mk
+++ b/common.mk
@@ -66,7 +66,7 @@ obj/%.o: %.c $(PREREQS)
 # Link a shared library
 $(SHARED_LIB_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
-	@$(CXX) -shared $(LDFLAGS) -o $@ $^
+	@$(CXX) -shared -o $@ $^ $(LDFLAGS)
 
 $(STATIC_LIB_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
@@ -75,7 +75,7 @@ $(STATIC_LIB_TARGETS): $(OBJS)
 # Link binary targets
 $(OTHER_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
-	@$(CXX) $(LDFLAGS) -o $@ $^
+	@$(CXX) -o $@ $^ $(LDFLAGS)
 
 # Set up build targets for benchmarking
 ifneq ($(BENCHMARK),)

--- a/libcoz/libcoz.cpp
+++ b/libcoz/libcoz.cpp
@@ -328,19 +328,19 @@ extern "C" {
   /// Run shutdown before exiting
   void __attribute__((noreturn)) exit(int status) throw() {
     profiler::get_instance().shutdown();
-    real::exit(status);
+    INVOKE_NONRETURN(real::exit(status));
   }
 
   /// Run shutdown before exiting
   void __attribute__((noreturn)) _exit(int status) {
     profiler::get_instance().shutdown();
-  	real::_exit(status);
+    INVOKE_NONRETURN(real::_exit(status));
   }
 
   /// Run shutdown before exiting
   void __attribute__((noreturn)) _Exit(int status) throw() {
     profiler::get_instance().shutdown();
-    real::_Exit(status);
+    INVOKE_NONRETURN(real::_Exit(status));
   }
 
   /// Don't allow programs to set signal handlers for causal's required signals

--- a/libcoz/profiler.cpp
+++ b/libcoz/profiler.cpp
@@ -442,7 +442,7 @@ int profiler::handle_pthread_create(pthread_t* thread,
  */
 void profiler::handle_pthread_exit(void* result) {
   end_sampling();
-  real::pthread_exit(result);
+  INVOKE_NONRETURN(real::pthread_exit(result));
 }
 
 void profiler::begin_sampling(thread_state* state) {

--- a/libcoz/real.cpp
+++ b/libcoz/real.cpp
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "util.h"
+
 static bool resolving = false;        //< Set to true while symbol resolution is in progress
 static bool in_dlopen = false;        //< Set to true while dlopen is running
 static void* pthread_handle = NULL;   //< The `dlopen` handle to libpthread
@@ -47,19 +49,19 @@ static void* get_pthread_handle() {
 
 static NORETURN void resolve_exit(int status) throw() {
   GET_SYMBOL(exit);
-  if(real_exit) real_exit(status);
+  if(real_exit) INVOKE_NONRETURN(real_exit(status));
   else abort();
 }
 
 static NORETURN void resolve__exit(int status) throw() {
   GET_SYMBOL(_exit);
-  if(real__exit) real__exit(status);
+  if(real__exit) INVOKE_NONRETURN(real__exit(status));
   else abort();
 }
 
 static NORETURN void resolve__Exit(int status) throw() {
   GET_SYMBOL(_Exit);
-  if(real__Exit) real__Exit(status);
+  if(real__Exit) INVOKE_NONRETURN(real__Exit(status));
   else abort();
 }
 
@@ -119,7 +121,7 @@ static int resolve_pthread_create(pthread_t* t, const pthread_attr_t* attr, void
 
 static NORETURN void resolve_pthread_exit(void* retval) {
   GET_SYMBOL_HANDLE(pthread_exit, get_pthread_handle());
-  if(real_pthread_exit) real_pthread_exit(retval);
+  if(real_pthread_exit) INVOKE_NONRETURN(real_pthread_exit(retval));
   else abort();
 }
 

--- a/libcoz/util.h
+++ b/libcoz/util.h
@@ -33,6 +33,10 @@ static size_t get_time() {
 #endif
 }
 
+/* Keep compilers happy about noreturn decorations. If stmt does not actually
+ * invoke a non-returning function, this will abort the program. */
+#define INVOKE_NONRETURN(stmt) do { stmt; abort(); } while (0)
+
 static inline size_t wait(size_t ns) {
   if(ns == 0) return 0;
 


### PR DESCRIPTION
Addresses some minor errors & warnings with the GNU compiler. Building depends on https://github.com/ccurtsinger/ccutil/pull/1 being merged as well; the same designated initializer problem exists there.

Have you considered including ccutils as a submodule rather than pulling the latest commit?