### PR TITLE
Sync types of copy_from_ring_buffer and its prototype

### DIFF
--- a/libcoz/perf.cpp
+++ b/libcoz/perf.cpp
@@ -203,7 +203,7 @@ bool perf_event::iterator::has_data() const {
 }
 
 void perf_event::copy_from_ring_buffer(struct perf_event_mmap_page* mapping,
-                                       uint64_t index, void* dest, size_t bytes) {
+                                       size_t index, void* dest, size_t bytes) {
   uintptr_t base = reinterpret_cast<uintptr_t>(mapping) + PageSize;
   size_t start_index = index % DataSize;
   size_t end_index = start_index + bytes;

--- a/libcoz/perf.cpp
+++ b/libcoz/perf.cpp
@@ -203,7 +203,7 @@ bool perf_event::iterator::has_data() const {
 }
 
 void perf_event::copy_from_ring_buffer(struct perf_event_mmap_page* mapping,
-                                       size_t index, void* dest, size_t bytes) {
+                                       ptrdiff_t index, void* dest, size_t bytes) {
   uintptr_t base = reinterpret_cast<uintptr_t>(mapping) + PageSize;
   size_t start_index = index % DataSize;
   size_t end_index = start_index + bytes;

--- a/libcoz/perf.h
+++ b/libcoz/perf.h
@@ -4,6 +4,7 @@
 #include <linux/perf_event.h>
 #include <sys/types.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 
@@ -183,7 +184,7 @@ private:
   
   // Copy data out of the mmap ring buffer
   static void copy_from_ring_buffer(struct perf_event_mmap_page* mapping,
-                                    size_t index, void* dest, size_t bytes);
+                                    ptrdiff_t index, void* dest, size_t bytes);
   
   /// File descriptor for the perf event
   long _fd = -1;


### PR DESCRIPTION
The prototype declares index as a size_t while the definition declares
it as a uint64_t. If I understand correctly, it's used a memory offset,
so size_t seems preferable.

This causes a build failure with Clang 3.4 on Ubuntu 14.04.3 LTS.