### PR TITLE
Add simple check target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ include $(ROOT)/common.mk
 bench::
 	@for dir in benchmarks ; do make -C $$dir $@; done
 
+check::
+	make -C libcoz $@
+
 install::
 	$(INSTALL) -D coz $(DESTDIR)$(bindir)/coz
 	$(INSTALL) -D include/coz.h $(DESTDIR)$(incdir)/coz.h

--- a/libcoz/Makefile
+++ b/libcoz/Makefile
@@ -7,5 +7,12 @@ PREREQS  := $(ROOT)/deps/ccutil $(ROOT)/deps/libelfin
 
 include $(ROOT)/common.mk
 
+check:: libcoz.so
+	printf "int main(int argc, char *argv[])\n{\nreturn (0);\n}\n" > x.c
+	gcc -Wl,-rpath,`pwd` -o x x.c libcoz.so -ldl || ( $(RM) x x.c ; exit 1)
+	./x
+	if grep -q time= profile.coz; then echo success: coz profiler ran as it should.; fi
+	$(RM) -f x.c x profile.coz
+
 install::
 	$(INSTALL) -D $(ROOT)/libcoz/libcoz.so $(DESTDIR)$(pkglibdir)/libcoz.so


### PR DESCRIPTION
This will test the coz library and make sure it is linkable and
the resulting binary is runnable.

This test detect a problem with GCC 6 that is missing with 4.9.