### PR TITLE
Implement 'distclean' target cleaning more than the 'clean' target. Connected to #56.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,8 @@ include $(ROOT)/common.mk
 install::
 	$(INSTALL) -D coz $(DESTDIR)$(bindir)/coz
 	$(INSTALL) -D include/coz.h $(DESTDIR)$(incdir)/coz.h
+
+distclean::
+	@for dir in deps/libelfin ; do \
+	make -C $$dir distclean || make -C $$dir clean; \
+	done

--- a/common.mk
+++ b/common.mk
@@ -27,7 +27,7 @@ SRCS    ?= $(wildcard *.cpp) $(wildcard *.c)
 OBJS    ?= $(addprefix obj/,$(patsubst %.cpp,%.o,$(patsubst %.c,%.o,$(SRCS))))
 
 # Targets to build recirsively into $(DIRS)
-RECURSIVE_TARGETS  ?= all clean bench test install
+RECURSIVE_TARGETS  ?= all clean distclean bench test install
 
 # Build in parallel
 MAKEFLAGS := -j
@@ -54,10 +54,13 @@ clean::
 	done
 	@rm -rf $(TARGETS) obj
 
+# Bring source back to pristine state
+distclean:: clean
+
 test::
 
-# Prevent errors if files named all, clean, bench, or test exist
-.PHONY: all clean bench test
+# Prevent errors if files named all, clean, distclean, bench, or test exist
+.PHONY: all clean distclean bench test
 
 # Compile a C++ source file (and generate its dependency rules)
 obj/%.o: %.cpp $(PREREQS)


### PR DESCRIPTION
Fixes issue #56.