### PR TITLE
Adjust deps.mk to rebuild libelfin when needed after 'make distclean'.

### DIFF
--- a/deps.mk
+++ b/deps.mk
@@ -12,10 +12,14 @@ CXXFLAGS += -I$(ROOT)/deps
 endif
 
 # Get and build libelfin
-$(ROOT)/deps/libelfin:
+$(ROOT)/deps/libelfin: $(ROOT)/deps/libelfin/elf/libelf++.a
+
+$(ROOT)/deps/libelfin/Makefile:
 	@echo $(LOG_PREFIX) Checking out libelfin $(LOG_SUFFIX)
 	@mkdir -p $(ROOT)/deps
 	@git clone git://github.com/ccurtsinger/libelfin $(ROOT)/deps/libelfin
+
+$(ROOT)/deps/libelfin/elf/libelf++.a: $(ROOT)/deps/libelfin/Makefile
 	@echo $(LOG_PREFIX) Building libelfin $(LOG_SUFFIX)
 	@cd $(ROOT)/deps/libelfin; make MAKEFLAGS="-j1" CC=$(CC) CXX=$(CXX)
 


### PR DESCRIPTION
This split the old target in two, one doing git clone and the other
building the libraries.