### PR TITLE
Specify libraries after object files when linking

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -20,7 +20,7 @@ endif
 # Default flags
 CFLAGS   ?= -g -O2
 CXXFLAGS ?= $(CFLAGS)
-LDFLAGS  += $(addprefix -l,$(LIBS))
+LDLIBS   += $(addprefix -l,$(LIBS))
 
 # Default source and object files
 SRCS    ?= $(wildcard *.cpp) $(wildcard *.c)
@@ -77,7 +77,7 @@ obj/%.o: %.c $(PREREQS)
 # Link a shared library
 $(SHARED_LIB_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
-	@$(CXX) -shared $(LDFLAGS) -o $@ $^
+	@$(CXX) -shared $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 $(STATIC_LIB_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
@@ -86,7 +86,7 @@ $(STATIC_LIB_TARGETS): $(OBJS)
 # Link binary targets
 $(OTHER_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
-	@$(CXX) $(LDFLAGS) -o $@ $^
+	@$(CXX) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 # Set up build targets for benchmarking
 ifneq ($(BENCHMARK),)


### PR DESCRIPTION
This prevents underlinking in Ubuntu where everything is linked with --as-needed by default.