### PR TITLE
Do not resolve the decl_file value from other DIEs than the one

### DIFF
--- a/libcoz/inspect.cpp
+++ b/libcoz/inspect.cpp
@@ -379,9 +379,8 @@ void memory_map::process_inlines(const dwarf::die& d,
       }
 
       string decl_file;
-      dwarf::value decl_file_val = find_attribute(d, dwarf::DW_AT::decl_file);
-      if(decl_file_val.valid() && table.valid()) {
-        decl_file = table.get_file(decl_file_val.as_uconstant())->path;
+      if(d.has(dwarf::DW_AT::decl_file) && table.valid()) {
+        decl_file = table.get_file(d[dwarf::DW_AT::decl_file].as_uconstant())->path;
       }
 
       size_t decl_line = 0;


### PR DESCRIPTION
requested.

The other DIEs might be part of another compilation unit, so the
index into the line_table taken from those DIEs might cause an
std::out_of_range exception when used on our line_table.

Fixes: #120