### PR TITLE
Adjust file base address with offset from /proc/self/maps

### DIFF
--- a/libcoz/inspect.cpp
+++ b/libcoz/inspect.cpp
@@ -246,7 +246,7 @@ unordered_map<string, uintptr_t> get_loaded_files() {
 
     // If this is an executable mapping of an absolute path, include it
     if(perms[2] == 'x' && path[0] == '/') {
-      result[path] = base;
+      result[path] = base - offset;
     }
   }
 


### PR DESCRIPTION
The `get_loaded_files()` function in inspect.cpp was meant to track the base address of each file loaded into a process' memory, but was not adjusting that base address using the offset field from`/proc/self/maps`. This *should* resolve that issue.