### PR TITLE
use own gettid() only for older glibc versions

### DIFF
--- a/libcoz/ccutil/thread.h
+++ b/libcoz/ccutil/thread.h
@@ -1,10 +1,17 @@
 #if !defined(CCUTIL_THREAD_H)
 #define CCUTIL_THREAD_H
 
+// gettid() is provided by glibc since version 2.30
+// only create our own implementation for older glibc versions
+#include <features.h>
+#if !__GLIBC_PREREQ(2,30)
+
 #include <sys/syscall.h>
 
 static inline pid_t gettid() {
   return syscall(__NR_gettid);
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
gettid() is provided in glibc since version 2.30. Detect the glibc version
with a macro and only define our own gettid() when glibc version < 2.30.