### PR TITLE
Use pkg-config to link in libelfin

### DIFF
--- a/benchmarks/histogram/Makefile
+++ b/benchmarks/histogram/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := histogram
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/kmeans/Makefile
+++ b/benchmarks/kmeans/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := kmeans
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/linear_regression/Makefile
+++ b/benchmarks/linear_regression/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := linear_regression
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/matrix_multiply/Makefile
+++ b/benchmarks/matrix_multiply/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := matrix_multiply
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2 -Wno-format
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/pbzip2/Makefile
+++ b/benchmarks/pbzip2/Makefile
@@ -1,6 +1,6 @@
 ROOT     := ../..
 TARGETS  := pbzip2
-LIBS     := bz2 pthread
+LIBS     := -lbz2 -lpthread
 CXXFLAGS := -g -O2 -Wno-format -Ibzip2-1.0.6
 LDFLAGS  := -Lbzip2-1.0.6
 

--- a/benchmarks/pca/Makefile
+++ b/benchmarks/pca/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := pca
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/producer_consumer/Makefile
+++ b/benchmarks/producer_consumer/Makefile
@@ -1,6 +1,6 @@
 ROOT     := ../..
 TARGETS  := producer_consumer
-LIBS     := pthread
+LIBS     := -lpthread
 CXXFLAGS := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/string_match/Makefile
+++ b/benchmarks/string_match/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := string_match
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/toy/Makefile
+++ b/benchmarks/toy/Makefile
@@ -1,6 +1,6 @@
 ROOT     := ../..
 TARGETS  := toy
-LIBS     := pthread
+LIBS     := -lpthread
 CXXFLAGS := --std=c++11 -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/benchmarks/word_count/Makefile
+++ b/benchmarks/word_count/Makefile
@@ -1,6 +1,6 @@
 ROOT    := ../..
 TARGETS := word_count
-LIBS    := pthread
+LIBS    := -lpthread
 CFLAGS  := -g -O2
 
 include $(ROOT)/benchmark.mk

--- a/common.mk
+++ b/common.mk
@@ -23,7 +23,6 @@ endif
 # Default flags
 CFLAGS   ?= -g -O2
 CXXFLAGS ?= $(CFLAGS)
-LDLIBS   += $(addprefix -l,$(LIBS))
 
 # Default source and object files
 SRCS ?= $(wildcard *.cpp) $(wildcard *.c)
@@ -79,7 +78,7 @@ obj/%.o: %.c $(PREREQS)
 # Link a shared library
 $(SHARED_LIB_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
-	@$(CXX) -shared $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	@$(CXX) -shared $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(STATIC_LIB_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
@@ -88,7 +87,7 @@ $(STATIC_LIB_TARGETS): $(OBJS)
 # Link binary targets
 $(OTHER_TARGETS): $(OBJS)
 	@echo $(LOG_PREFIX) Linking $@ $(LOG_SUFFIX)
-	@$(CXX) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	@$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 # Include dependency rules for all objects
 -include $(OBJS:.o=.d)

--- a/libcoz/Makefile
+++ b/libcoz/Makefile
@@ -1,6 +1,6 @@
 ROOT 		 := ..
 TARGETS  := libcoz.so
-LIBS     := dl rt pthread elf++ dwarf++
+LIBS     := -ldl -lrt -lpthread $(shell pkg-config --libs libelf++ libdwarf++)
 CXXFLAGS := --std=c++0x -g -O2 -fPIC -I$(ROOT)/include -I.
 
 include $(ROOT)/common.mk

--- a/libcoz/Makefile
+++ b/libcoz/Makefile
@@ -1,7 +1,8 @@
 ROOT 		 := ..
 TARGETS  := libcoz.so
 LIBS     := -ldl -lrt -lpthread $(shell pkg-config --libs libelf++ libdwarf++)
-CXXFLAGS := --std=c++0x -g -O2 -fPIC -I$(ROOT)/include -I.
+CXXFLAGS := --std=c++0x -g -O2 -fPIC -I$(ROOT)/include -I. \
+            $(shell pkg-config --cflags libelf++ libdwarf++)
 
 include $(ROOT)/common.mk
 


### PR DESCRIPTION
Some users saw libelfin installed under /usr/local/lib, which was not in their ld search path. Use pkg-config to generate libelfin compilation and linking flags to handle this case.