### PR TITLE
Fail when a --fixed-line is given and it is not found

### DIFF
--- a/libcoz/libcoz.cpp
+++ b/libcoz/libcoz.cpp
@@ -146,7 +146,7 @@ void init_coz(void) {
   shared_ptr<line> fixed_line;
   if(fixed_line_name != "") {
     fixed_line = memory_map::get_instance().find_line(fixed_line_name);
-    PREFER(fixed_line) << "Fixed line \"" << fixed_line_name << "\" was not found.";
+    REQUIRE(fixed_line) << "Fixed line \"" << fixed_line_name << "\" was not found.";
   }
 
   // Create an end-to-end progress point and register it if running in


### PR DESCRIPTION
Hi, thanks for making coz!

I've been using it a bit on toy programs, with coz-rs.

This PR:
I think the run should fail if we don't find the fixed line we're told to experiment on. Do you agree?

Also, I'd like to write+submit PRs for these, what do you think of these ergonomic improvements?

* If a given `--fixed-line` is not found, show which line numbers in that source file are loaded in the `memory_map`.

I have this locally and it has helped me a lot because often with Rust (and maybe its closures or all the macro usage), not all lines end up showing up. Knowing which lines are accessible helps a lot.

* The possibility of passing several `--fixed-line` parameters

For example, one might want to compare several different locations in a program at once, instead of in separate runs.

A natural ergonomic follow-up:
* Allow passing a range of speedups eg `--fixed-speedup 40-100` or `--fixed-speedup 0-30`

This might be useful because in many programs you don't really expect to speedup most functions by more than 40%, so it might speed up runs by needing to collect less data / instead collecting more data to get more accuracy on the range you care about.

An even further solution might even allow passing an extra step value (eg `--fixed-speedup 0-40:2` = 0 to 40 by steps of 2) if someone wants control over the granularity of the speedups.

Let me know what you think and I'll get to submitting them! I might also drop a couple other small PRs for papercuts I've encountered so far.