### PR TITLE
Rust: Document `scope` in favor of `begin`/`end`.

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -43,13 +43,11 @@ If you'd like to profile the latency of an operation you can instead use:
 ```rust
 // Boy I wish this function executed more quickly...
 fn foo() {
-    coz::begin!("foo");
-
-    // ...
-
-    coz::end!("foo");
+    coz::scope!("foo");
 }
 ```
+
+Instead of `scope!` you may also use `coz::begin!("foo"); ... coz::end!("foo");`.
 
 After you've instrumented your code, you need to also ensure that you're
 compiling with DWARF debug information. To do this you'll want to configure


### PR DESCRIPTION
`scope` is preferable (IMO) to `begin` and `end`. Let's show this in the documentation.