### PR TITLE
Use python3 for coz entry point

### DIFF
--- a/coz
+++ b/coz
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (c) 2019, Charlie Curtsinger and Emery Berger,
 #                     University of Massachusetts Amherst

--- a/coz
+++ b/coz
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 # Copyright (c) 2019, Charlie Curtsinger and Emery Berger,
 #                     University of Massachusetts Amherst


### PR DESCRIPTION
Feel free to change/ignore if inappropriate - I ran into this issue on a system without python2.x, building from source. The main `coz` file seemed to be the culprit, but I may be wrong.

Given that the README isn't picky about a python interpreter for building from source (Python3 is merely recommended), it may be better to change this line to `/usr/bin/env python`, instead of `python3`/`python2.7`. I don't know what would be preferred, and it should be fairly trivial to change :)

Just figured I'd open discussion in a place that's easiest to resolve it.