### PR TITLE
Fixed issue with gettid() not available with glibc < 2.30.

### DIFF
--- a/libcoz/perf.h
+++ b/libcoz/perf.h
@@ -18,6 +18,11 @@
 #include "ccutil/log.h"
 #include "ccutil/wrapped_array.h"
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
+#endif
+
 // Workaround for missing hw_breakpoint.h include file:
 //   This include file just defines constants used to configure watchpoint registers.
 //   This will be constant across x86 systems.


### PR DESCRIPTION
In that case use the syscall interface directly

https://stackoverflow.com/questions/30680550/c-gettid-was-not-declared-in-this-scope
Fixes #154 