### PR TITLE
Add -ldl to benchmark build rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ install:: all
 
 bench bench_small bench_large::
 	@$(MAKE) -C benchmarks $@
+
+check::
+	@$(MAKE) -C benchmarks check

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -4,3 +4,13 @@ DIRS := histogram kmeans linear_regression matrix_multiply \
 				sqlite-modified toy word_count
 
 include $(ROOT)/common.mk
+
+check::
+	@$(MAKE) -C kmeans
+	@$(RM) -f profile.coz
+	../coz run --- kmeans/kmeans
+	@grep -q "time=" profile.coz || { echo failure: valid profile.coz not generated; exit 1; }
+	@grep -q "throughput-point" profile.coz || { echo failure: throughput-point not found in profile; exit 1; }
+	@grep -q -P "samples\tlocation=" profile.coz || { echo failure: samples not found in profile; exit 1; }
+	@echo success: benchmark generated valid profile.coz
+	@$(RM) -f profile.coz


### PR DESCRIPTION
Fixes #166 

**Commit 1**
Adds a check rule which builds and runs the kmeans benchmark and verifies its profile.coz contains the expected entry types.

Expected to fail CI for clang, due to missing -ldl.  Also fails for earlier versions of g++ (not covered by CI).

It has been pushed as a separate commit to validate that CI does indeed fail.

**Commit 2**
Subsequent commit provides the fix, with CI passing.

Adds -ldl to benchmark build rules, with an explicit `--no-as-needed` to support older toolchains.

**Notes**
Given that it appears the `--no-as-needed` option is only required for older toolchains (and even then, potentially only when combined with older loaders that don't satisfy the weak symbol at load-time), I opted against mentioning it in the README.

If there *is* an appropriate place to mention this potential surprise, please let me know.