### PR TITLE
Add -ldl to benchmark build rules

### DIFF
--- a/benchmark.mk
+++ b/benchmark.mk
@@ -1,5 +1,7 @@
 include $(ROOT)/common.mk
 
+LIBS += -Wl,--push-state,--no-as-needed -ldl -Wl,--pop-state
+
 RECURSIVE_TARGETS += bench bench_large bench_small
 
 ifeq ($(USE_SYSTEM_COZ),)


### PR DESCRIPTION
Explicitly specifies --no-as-needed to support toolchains that skip
libraries that are not referenced in the object code (or are only
referenced by weak symbols, such as coz.h's dlsym symbol).

Follow-on to PR 167, with the fix for the (intentionally-introduced) CI failure.

Resolves #166 