### PR TITLE
Improve developer's first experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ benchmarks/pbzip2/bzip2-1.0.6
 benchmarks/string_match/string_match_datafiles
 benchmarks/word_count/word_count_datafiles
 
+build/
+
 viewer/node_modules
 rust/Cargo.lock
 rust/target

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ $ pip install conan --user
 $ git clone https://github.com/plasma-umass/coz.git
 $ cd coz
 $ mkdir build && cd build
+$ # This helps to avoid problems with linker failing to find C++ symbols:
+$ conan profile update settings.compiler.libcxx=libstdc++11 default
 $ conan install ..
 $ cmake ..
 $ make

--- a/coz
+++ b/coz
@@ -59,7 +59,9 @@ def _coz_run(args):
     os.path.join(coz_prefix, '..', 'lib', 'coz-profiler', 'libcoz.so'),
 
     # Local library under development directory
-    os.path.join('libcoz', 'libcoz.so')      # Local library during development
+    os.path.join('libcoz', 'libcoz.so'),      # Local library during development
+    os.path.join(coz_prefix, 'libcoz', 'libcoz.so'),
+    os.path.join(coz_prefix, 'build', 'libcoz', 'libcoz.so'),
   ]
 
   # Find the first library location that exists


### PR DESCRIPTION
When new developers try to use coz to profile their programs, and find out that coz has some problems it is difficult to start debugging coz itself.

First there is issue with linker failing to find symbol as reported in #181 and also resolved in #185 . So it might be good to add that trick to build instructions in README.

Also build instructions suggest creating build directory in the repository directory. That is OK, but it would be OK, then, to put that directory to gitignore.

Also it seems like code that looks for libcoz.so in coz's main python script, is outdated and doesn't quite work well with CMake generating build directory and putting all output files in that directory. So adding build directory to search path for libcoz.so, makes it much easier for new developers to start debugging coz, after building it from source.

So this PR basically aligns code with README instructions and vice versa.