### PR TITLE
Issue #176: avoid recursive call on allocator on library initializaton

### DIFF
--- a/coz
+++ b/coz
@@ -79,7 +79,7 @@ def _coz_run(args):
     sys.exit(1)
 
   if 'LD_PRELOAD' in env:
-    env['LD_PRELOAD'] += ':' + coz_runtime
+    env['LD_PRELOAD'] = coz_runtime + ':' + env['LD_PRELOAD']
   else:
     env['LD_PRELOAD'] = coz_runtime
 

--- a/libcoz/libcoz.cpp
+++ b/libcoz/libcoz.cpp
@@ -236,6 +236,7 @@ class LocalArena {
 
 public:
   void * allocate(size_t bytes_requested) {
+    bytes_requested = (bytes_requested + 8) & ((~0ull) << 3);
     char * prev = _offset.fetch_add(bytes_requested, std::memory_order_relaxed);
     if (prev + bytes_requested > _data.end()) {
       std::abort();

--- a/libcoz/real.cpp
+++ b/libcoz/real.cpp
@@ -51,6 +51,23 @@ static void* get_pthread_handle() {
  * located function is called.
  */
 
+static void * resolve_calloc(size_t nmemb, size_t size) throw() {
+  GET_SYMBOL(calloc);
+  if(real_calloc) return real_calloc(nmemb, size);
+  return nullptr;
+}
+
+static void * resolve_malloc(size_t size) throw() {
+  GET_SYMBOL(malloc);
+  if(real_malloc) return real_malloc(size);
+  return nullptr;
+}
+
+static void resolve_free(void * ptr) throw() {
+  GET_SYMBOL(free);
+  if(real_free) real_free(ptr);
+}
+
 static NORETURN void resolve_exit(int status) throw() {
   GET_SYMBOL(exit);
   if(real_exit) real_exit(status);
@@ -262,6 +279,10 @@ static int resolve_pthread_rwlock_unlock(pthread_rwlock_t* rwlock) throw() {
  * corresponding resolver function.
  */
 namespace real {
+  DEFINE_WRAPPER(malloc);
+  DEFINE_WRAPPER(calloc);
+  DEFINE_WRAPPER(free);
+
   DEFINE_WRAPPER(exit);
   DEFINE_WRAPPER(_exit);
   DEFINE_WRAPPER(_Exit);

--- a/libcoz/real.h
+++ b/libcoz/real.h
@@ -16,6 +16,9 @@
 #define DECLARE_WRAPPER(name) extern decltype(::name)* name;
 
 namespace real {
+  DECLARE_WRAPPER(malloc);
+  DECLARE_WRAPPER(calloc);
+  DECLARE_WRAPPER(free);
   DECLARE_WRAPPER(exit);
   DECLARE_WRAPPER(_exit);
   DECLARE_WRAPPER(_Exit);


### PR DESCRIPTION
This PR solves issues #98 and #176.

First, libcoz must provide basic allocator via malloc/calloc (for dlsym)
to avoid clash with user' allocator like jemalloc

Second, libcoz must be preloaded before any other to override any other
allocator implementation

Third, once libcoz is initialized (right before real main) disable
internal allocator and pass requests through