### PR TITLE
[Rust] Remove thread_init

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -65,16 +65,6 @@ finally you can run it with `coz run --- ./target/release/$your_binary`.
 
 Known caveats so far to generate a report that collects information are:
 
-* Rust programs by default segfault when run with `coz` with an issue related to
-  [plasma-umass/coz#110](https://github.com/plasma-umass/coz/issues/110). Rust
-  programs set up a `sigaltstack` to run segfault handlers to print "you ran out
-  of stack", but this alternate stack is too small to run the `SIGPROF` handler
-  that `coz` installs. To handle this this crate provides a `coz::thread_init()`
-  function which will increase the `sigaltstack` size that Rust installs by
-  default to something large enough to run `coz`. If you see segfaults, or
-  corrupt reports, you may wish to manually call `coz::thread_init()` instead of
-  waiting for this crate to automatically call it for you.
-
 * Debug information looks to be critical to get a report from `coz`. Make sure
   that your program is compiled with at least line-table information (`debug =
   1`) to ensure you get the best experience using `coz`.

--- a/rust/examples/toy.rs
+++ b/rust/examples/toy.rs
@@ -2,16 +2,12 @@ const A: usize = 2_000_000_000;
 const B: usize = (A as f64 * 1.2) as usize;
 
 fn main() {
-    coz::thread_init();
-
     let a = std::thread::spawn(move || {
-        coz::thread_init();
         for _ in 0..A {
             coz::progress!("a");
         }
     });
     let b = std::thread::spawn(move || {
-        coz::thread_init();
         for _ in 0..B {
             coz::progress!("b");
         }


### PR DESCRIPTION
After fixing #110 the function `thread_init` is not needed anymore.

This PR removes the function, its usage in the crate and the out of date caveat. This is a breaking change to the API, but in because the crate has not reached version `1.x` this is considered ok in the Rust ecosystem (which tries to use SemVer). Before publishing to crates.io the crate version should be bumped to `0.2.x` to signal the a breaking change.  If the breaking change is not desired another option is to leave a dummy `thread_init` function that has no effect.

The changes have been tested with one of my programs, the `toy` example and with `cargo test`.