### PR TITLE
Fix README apt installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ that Counts with Causal Profiling
 
 ## Installation
 
-On Debian, Ubuntu, you can install Coz via apt:
+On Debian and Ubuntu, you can install Coz via apt:
 
 ```shell
 sudo apt install coz-profiler

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ that Counts with Causal Profiling
 
 ## Installation
 
-On Debian, Ubuntu, and Fedora, you can install Coz via apt:
+On Debian, Ubuntu, you can install Coz via apt:
 
 ```shell
 sudo apt install coz-profiler


### PR DESCRIPTION
Fedora doesn't use `apt` 