### PR TITLE
Fix CSS for highlighted line in `coz plot` source panel

### DIFF
--- a/viewer/css/plot.css
+++ b/viewer/css/plot.css
@@ -358,6 +358,9 @@ div.plot.source-open {
 }
 
 .source-panel {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
   position: absolute;
   left: 0;
   right: 0;
@@ -375,7 +378,6 @@ div.plot.source-open {
 }
 
 .source-line {
-  display: flex;
   padding: 1px 8px;
   white-space: pre;
 }


### PR DESCRIPTION
### Summary

The existing styling for `.source-line` and `.source-panel` doesn't handle `overflow-x: auto` correctly. While not a huge deal, it certainly bugs me whenever I scroll through code horizontally. So I thought I'd fix it!

#### Before:
<img width="1029" height="345" alt="Coz Profiler Viewer (Before)" src="https://github.com/user-attachments/assets/30e7fb5d-d9cd-4c4d-a974-02928d5fb570" />

#### After:
<img width="1028" height="347" alt="Coz Profiler Viewer (After)" src="https://github.com/user-attachments/assets/4af1e6b1-f1aa-46ed-8851-8f4b9b206709" /> |

Thanks for your terrific work on `coz` over the years! I really love this tool, despite all the little bugs, and I'm sure that plenty of folks would love to see it keep getting even better. :heart: 