### PR TITLE
Add Go bindings for coz

### DIFF
--- a/.github/scripts/check_profile.py
+++ b/.github/scripts/check_profile.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Assert that a coz profile contains experiments attributed to a source file.
+
+Usage: check_profile.py <profile.jsonl> <expected-source-substring>
+
+Used by the per-language CI jobs. A binding is only "working" if libcoz both
+registered its progress points and attributed experiments back to that
+language's source, so this checks for experiment records naming the file.
+"""
+import collections
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <profile.jsonl> <expected-source-substring>")
+        return 2
+
+    path, expected = sys.argv[1], sys.argv[2]
+
+    records = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    kinds = collections.Counter(r["type"] for r in records)
+    print(f"record types: {dict(kinds)}")
+
+    experiments = [r for r in records if r["type"] == "experiment"]
+    if not experiments:
+        print("ERROR: profile contains no experiments")
+        return 1
+
+    matching = [e for e in experiments if expected in e.get("selected", "")]
+    selected = collections.Counter(e.get("selected", "") for e in experiments)
+    print(f"experiments: {len(experiments)} ({len(matching)} naming {expected!r})")
+    for location, count in selected.most_common(10):
+        print(f"  {count:4d}  {location}")
+
+    if not matching:
+        print(f"ERROR: no experiment selected a line in {expected!r}")
+        return 1
+
+    print(f"OK: {len(matching)} experiments attributed to {expected!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build build -j3
-        test -f build/libcoz/libcoz.so
+        test -f build/libcoz/libcoz.so || test -f build/libcoz/libcoz.dylib
 
     - name: Check the crate on both platforms
       working-directory: rust
@@ -371,7 +371,7 @@ jobs:
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build build -j3
-        test -f build/libcoz/libcoz.so
+        test -f build/libcoz/libcoz.so || test -f build/libcoz/libcoz.dylib
 
     - name: Vet, format and test
       working-directory: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,60 @@ jobs:
         fi
         echo "Profile created:"
         cat profile.jsonl
+
+  lang-go:
+    name: Go bindings (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake pkg-config
+        echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install pkg-config coreutils || true
+
+    - name: Build coz
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake --build build -j3
+        test -f build/libcoz/libcoz.so
+
+    - name: Vet, format and test
+      working-directory: go
+      run: |
+        test -z "$(gofmt -l .)" || { echo "gofmt found unformatted files:"; gofmt -l .; exit 1; }
+        go vet ./...
+        go test -race ./...
+        # The package must also build with cgo off, degrading to no-ops.
+        CGO_ENABLED=0 go build ./...
+
+    - name: Build the Go toy
+      working-directory: go
+      run: |
+        # coz cannot read Go's compressed DWARF (.zdebug_* / __zdebug_*).
+        go build -ldflags=-compressdwarf=false -o "$RUNNER_TEMP/gotoy" ./example
+
+    - name: Profile the Go toy under coz
+      run: |
+        TIMEOUT=timeout
+        command -v gtimeout >/dev/null && TIMEOUT=gtimeout
+        $TIMEOUT 180 ./coz run -o profile.jsonl --- "$RUNNER_TEMP/gotoy" || true
+        test -s profile.jsonl
+
+    - name: Validate the Go profile
+      run: python3 .github/scripts/check_profile.py profile.jsonl toy.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,141 @@
+# coz-go
+
+Go support for the [`coz` causal profiler](https://github.com/plasma-umass/coz).
+
+A traditional profiler tells you *where* your program spends time. Coz tells you
+whether optimizing a line would actually make the program faster — which, in
+concurrent code, is a different question.
+
+Works on **Linux** and **macOS**.
+
+## Usage
+
+First [install `coz`](https://github.com/plasma-umass/coz#installation), then add
+the module:
+
+```
+go get github.com/plasma-umass/coz/go
+```
+
+Mark the points where your program makes progress. For throughput — "I wish this
+happened more often":
+
+```go
+import coz "github.com/plasma-umass/coz/go"
+
+for _, req := range requests {
+    handle(req)
+    coz.Progress()               // equivalent of COZ_PROGRESS
+}
+```
+
+`coz.ProgressNamed("requests")` is the equivalent of `COZ_PROGRESS_NAMED`.
+
+For latency — "I wish this finished sooner" — mark both ends of the operation:
+
+```go
+func handle(req Request) {
+    defer coz.Scope("request")()   // COZ_BEGIN now, COZ_END on return
+    // ...
+}
+```
+
+`Scope` fires its end counter even on an early return or a panic. If you need the
+two halves apart, `coz.Begin("request")` and `coz.End("request")` are available.
+
+On a hot path you can hoist the counter lookup out of the loop:
+
+```go
+requests := coz.NewThroughput("requests")
+for _, req := range reqs {
+    handle(req)
+    requests.Increment()
+}
+```
+
+`coz.Available()` reports whether the program is running under `coz run`.
+
+## Building and running
+
+Profiling requires **cgo** (`CGO_ENABLED=1`, the default when a C toolchain is
+present), because reaching libcoz means calling `dlsym`. With `CGO_ENABLED=0`
+this package still builds — every entry point compiles to a no-op — so you can
+leave progress points in code that also ships as a static binary.
+
+Coz needs DWARF line tables, and it cannot read the compressed DWARF that Go's
+linker emits by default. Build with compression off:
+
+```
+go build -ldflags=-compressdwarf=false -o myapp .
+coz run --- ./myapp
+coz plot --text
+```
+
+Without `-compressdwarf=false`, Go emits `.zdebug_*` (ELF) / `__zdebug_*`
+(Mach-O) sections and coz will report "Debug information was not found."
+
+If line attribution looks coarse because of inlining, also pass
+`-gcflags=all=-l` to disable inlining, or `-gcflags=all='-N -l'` to disable
+optimization entirely. Both change the performance profile of the program, so
+prefer leaving them off unless you need the extra source fidelity.
+
+## Example
+
+`example/toy.go` runs two goroutines per round; one does twice the work of the
+other, so it sits on the critical path.
+
+```
+go build -ldflags=-compressdwarf=false -o toy ./example
+coz run --- ./toy
+coz plot --text
+```
+
+```
+Source Line                |   Slope |    R² | Max Speedup | Points
+---------------------------+---------+-------+-------------+-------
+go/example/toy.go:35       |   1.082 |  0.91 | +     29.9% |     4
+go/example/toy.go:41       |   0.137 |  1.00 | +      8.9% |     2
+```
+
+Line 35 is the loop inside `slowWork` and line 41 the loop inside `fastWork`.
+Coz correctly predicts that speeding up `slowWork` speeds up the program roughly
+proportionally, while `fastWork` is nearly irrelevant.
+
+## Caveats
+
+**Do not use `runtime/pprof` CPU profiling at the same time.** Coz samples with
+`SIGPROF`, which is the same signal Go's own CPU profiler uses; the two cannot
+both own it. Calling `pprof.StartCPUProfile` under `coz run` will fight coz for
+the signal. Memory, block, and mutex profiles are unaffected.
+
+**Results are per-OS-thread, not per-goroutine.** Coz's virtual speedup works by
+delaying threads. Go multiplexes goroutines onto OS threads (`GOMAXPROCS`), so a
+progress point tells you about the thread that executed it, and a goroutine that
+migrates between threads is not tracked as a unit. In practice this is fine for
+CPU-bound work, but a goroutine that is descheduled mid-operation may attribute
+some of its delay elsewhere.
+
+**Progress points must be reached often enough.** Coz needs at least a handful of
+progress-point visits per experiment (roughly 5), and each experiment runs for
+about half a second. A program that reaches its progress point a dozen times
+total will produce very few data points.
+
+**On Linux, `coz plot` reports `Runtime: 0.0s` for Go programs.** Go's runtime
+exits with a direct `exit_group` syscall rather than libc's `exit`, so coz's
+shutdown hook never runs and the final `runtime` record is not written. The
+per-experiment records are flushed as they complete, so the profile itself is
+intact; only the total-runtime line (used for phase correction) is missing.
+
+## How it works
+
+`coz_shim.c` resolves `_coz_get_counter` and `_coz_add_delays` out of the
+injected `libcoz` with `dlsym(RTLD_DEFAULT, ...)`. That means the package does
+not need `coz.h` installed at build time, and a binary built against it runs
+normally when `libcoz` is absent — every entry point degrades to a no-op.
+
+Incrementing a counter is a plain relaxed atomic add on memory owned by `libcoz`,
+performed from Go, so there is no cgo call on the hot path on Linux. On macOS
+each progress point additionally calls `_coz_add_delays()`, because macOS has no
+per-thread sampling timer and a worker thread only discovers the virtual delay it
+owes when it reaches a progress point. This mirrors `_COZ_CHECK_DELAYS` in
+`include/coz.h`.

--- a/go/coz.go
+++ b/go/coz.go
@@ -1,0 +1,224 @@
+//go:build cgo
+
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+// Package coz provides Go support for the coz causal profiler.
+//
+// Coz answers "if I optimize this line, will the program actually get faster?"
+// To use it, mark the points where your program makes progress, build with
+// uncompressed DWARF, and run the binary under `coz run`:
+//
+//	go build -ldflags=-compressdwarf=false -o myapp .
+//	coz run --- ./myapp
+//
+// Throughput profiling measures how often a progress point is reached:
+//
+//	for _, req := range requests {
+//	    handle(req)
+//	    coz.Progress()
+//	}
+//
+// Latency profiling measures the time between a matched pair of points, via
+// Little's law:
+//
+//	func handle(req Request) {
+//	    defer coz.Scope("request")()
+//	    // ...
+//	}
+//
+// When the program is not running under `coz run`, libcoz is absent, every
+// entry point here is a cheap no-op, and the program behaves normally.
+//
+// # Interaction with runtime/pprof
+//
+// Coz samples using SIGPROF, which is the same signal Go's own CPU profiler
+// uses. Do not call pprof.StartCPUProfile while profiling under coz; the two
+// cannot both own the signal. See the package README for details.
+package coz
+
+/*
+#cgo linux CFLAGS: -D_GNU_SOURCE
+#cgo linux LDFLAGS: -ldl
+
+#include <stdlib.h>
+#include "coz_shim.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+// Counter type constants, matching include/coz.h.
+const (
+	counterThroughput = C.COZ_SHIM_THROUGHPUT
+	counterBegin      = C.COZ_SHIM_BEGIN
+	counterEnd        = C.COZ_SHIM_END
+)
+
+var initOnce sync.Once
+
+func ensureInit() {
+	initOnce.Do(func() { C.coz_shim_init() })
+}
+
+// Available reports whether the coz runtime was found, i.e. whether this
+// process is running under `coz run`. It is useful in tests and for skipping
+// expensive instrumentation when not profiling.
+func Available() bool {
+	ensureInit()
+	return C.coz_shim_available() != 0
+}
+
+// A Counter is a handle to one of libcoz's progress-point counters.
+//
+// Resolving a counter by name costs a cgo call and a lock inside libcoz, so hot
+// call sites should hold onto a Counter rather than passing a name on every
+// hit. The package-level helpers (Progress, Begin, End) cache Counters for you,
+// but that cache costs a map lookup per hit; NewThroughput and friends let you
+// skip even that.
+//
+// The zero Counter is valid and does nothing, which is what you get when the
+// program runs without the profiler.
+type Counter struct {
+	// count aliases the `count` field of libcoz's coz_counter_t, which is a
+	// size_t and therefore uintptr-sized. It is nil when not profiling.
+	count *uintptr
+}
+
+// NewThroughput returns a throughput (COZ_PROGRESS_NAMED) counter.
+func NewThroughput(name string) *Counter { return newCounter(counterThroughput, name) }
+
+// NewBegin returns the opening counter of a latency pair (COZ_BEGIN).
+func NewBegin(name string) *Counter { return newCounter(counterBegin, name) }
+
+// NewEnd returns the closing counter of a latency pair (COZ_END).
+func NewEnd(name string) *Counter { return newCounter(counterEnd, name) }
+
+func newCounter(typ C.int, name string) *Counter {
+	ensureInit()
+
+	cname := C.CString(name)
+	// libcoz copies the name into its own table, so the C string is ours to
+	// free as soon as the call returns.
+	defer C.free(unsafe.Pointer(cname))
+
+	ptr := C.coz_shim_get_counter(typ, cname)
+	if ptr == nil {
+		return &Counter{}
+	}
+	// `count` is the first field of coz_counter_t, so the struct address is
+	// also the address of the counter itself.
+	return &Counter{count: (*uintptr)(unsafe.Pointer(ptr))}
+}
+
+// Increment records one visit to this progress point.
+//
+// It is safe to call from multiple goroutines concurrently, and is a no-op on a
+// Counter obtained while not profiling.
+func (c *Counter) Increment() {
+	if c == nil || c.count == nil {
+		return
+	}
+	// Mirrors COZ_INCREMENT_COUNTER in include/coz.h: a relaxed atomic bump of
+	// the shared counter, then a check for any virtual delay this thread owes.
+	atomic.AddUintptr(c.count, 1)
+	checkDelays()
+}
+
+// counterCache memoizes name -> *Counter so the package-level helpers avoid a
+// cgo call on every progress point.
+var counterCache sync.Map // cacheKey -> *Counter
+
+type cacheKey struct {
+	typ  C.int
+	name string
+}
+
+func cachedCounter(typ C.int, name string) *Counter {
+	key := cacheKey{typ: typ, name: name}
+	if c, ok := counterCache.Load(key); ok {
+		return c.(*Counter)
+	}
+	c := newCounter(typ, name)
+	actual, _ := counterCache.LoadOrStore(key, c)
+	return actual.(*Counter)
+}
+
+// ProgressNamed records a visit to the named throughput progress point.
+// It is the equivalent of the COZ_PROGRESS_NAMED macro.
+func ProgressNamed(name string) {
+	cachedCounter(counterThroughput, name).Increment()
+}
+
+// Progress records a visit to a throughput progress point named after the
+// calling file and line, the equivalent of the COZ_PROGRESS macro.
+//
+// Determining the call site costs a stack lookup. Prefer ProgressNamed, or hold
+// a Counter from NewThroughput, on very hot paths.
+func Progress() {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		ProgressNamed("unknown")
+		return
+	}
+	if c, hit := pcCache.Load(pc); hit {
+		c.(*Counter).Increment()
+		return
+	}
+	name := callSiteName(pc)
+	c := cachedCounter(counterThroughput, name)
+	pcCache.Store(pc, c)
+	c.Increment()
+}
+
+// pcCache memoizes caller PC -> *Counter for Progress.
+var pcCache sync.Map // uintptr -> *Counter
+
+// callSiteName renders a program counter as "file:line", matching the naming
+// that COZ_PROGRESS produces from __FILE__ and __LINE__.
+func callSiteName(pc uintptr) string {
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return "unknown"
+	}
+	// pc is the return address; step back into the call instruction so the
+	// reported line is the coz.Progress() call rather than the line after it.
+	file, line := fn.FileLine(pc - 1)
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+// Begin marks the start of a latency-profiled operation, the equivalent of the
+// COZ_BEGIN macro. It must be paired with an End of the same name.
+func Begin(name string) {
+	cachedCounter(counterBegin, name).Increment()
+}
+
+// End marks the completion of a latency-profiled operation, the equivalent of
+// the COZ_END macro. It must be paired with a Begin of the same name.
+func End(name string) {
+	cachedCounter(counterEnd, name).Increment()
+}
+
+// Scope marks the start of a latency-profiled operation and returns a function
+// that marks its end, so the pair survives early returns and panics:
+//
+//	func handle(req Request) {
+//	    defer coz.Scope("request")()
+//	    // ...
+//	}
+func Scope(name string) func() {
+	begin := cachedCounter(counterBegin, name)
+	end := cachedCounter(counterEnd, name)
+	begin.Increment()
+	return end.Increment
+}

--- a/go/coz_nocgo.go
+++ b/go/coz_nocgo.go
@@ -1,0 +1,51 @@
+//go:build !cgo
+
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+// Pure-Go no-op implementation for CGO_ENABLED=0 builds.
+//
+// Reaching libcoz requires dlsym, which requires cgo, and coz profiles a binary
+// by injecting libcoz into it at load time -- neither of which applies to a
+// static CGO_ENABLED=0 binary. Rather than break the build of any package that
+// imports coz, this stub keeps the API present and inert, so a project can leave
+// its progress points in place and simply build with cgo enabled when it wants
+// to profile.
+package coz
+
+// Available always reports false without cgo.
+func Available() bool { return false }
+
+// A Counter is an inert progress-point handle.
+type Counter struct{}
+
+// NewThroughput returns an inert throughput counter.
+func NewThroughput(string) *Counter { return &Counter{} }
+
+// NewBegin returns an inert latency-begin counter.
+func NewBegin(string) *Counter { return &Counter{} }
+
+// NewEnd returns an inert latency-end counter.
+func NewEnd(string) *Counter { return &Counter{} }
+
+// Increment does nothing.
+func (c *Counter) Increment() {}
+
+// Progress does nothing.
+func Progress() {}
+
+// ProgressNamed does nothing.
+func ProgressNamed(string) {}
+
+// Begin does nothing.
+func Begin(string) {}
+
+// End does nothing.
+func End(string) {}
+
+// Scope does nothing and returns a function that does nothing.
+func Scope(string) func() { return func() {} }

--- a/go/coz_shim.c
+++ b/go/coz_shim.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+/* RTLD_DEFAULT is a GNU extension on glibc. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "coz_shim.h"
+
+#include <dlfcn.h>
+#include <stddef.h>
+
+typedef coz_counter_t* (*coz_get_counter_t)(int, const char*);
+typedef void (*coz_add_delays_t)(void);
+
+static coz_get_counter_t s_get_counter;
+static coz_add_delays_t s_add_delays;
+
+void coz_shim_init(void) {
+  /* libcoz is injected by `coz run` via LD_PRELOAD / DYLD_INSERT_LIBRARIES, so
+   * its symbols are in the global scope and RTLD_DEFAULT finds them. When the
+   * program runs without the profiler these stay NULL and every entry point
+   * below degrades to a no-op. */
+  s_get_counter = (coz_get_counter_t)dlsym(RTLD_DEFAULT, "_coz_get_counter");
+  s_add_delays = (coz_add_delays_t)dlsym(RTLD_DEFAULT, "_coz_add_delays");
+}
+
+int coz_shim_available(void) { return s_get_counter != NULL; }
+
+coz_counter_t* coz_shim_get_counter(int type, const char* name) {
+  if (s_get_counter == NULL) return NULL;
+  return s_get_counter(type, name);
+}
+
+void coz_shim_add_delays(void) {
+  if (s_add_delays != NULL) s_add_delays();
+}

--- a/go/coz_shim.h
+++ b/go/coz_shim.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+#ifndef COZ_GO_SHIM_H
+#define COZ_GO_SHIM_H
+
+#include <stddef.h>
+
+/* Mirrors coz_counter_t in include/coz.h. */
+typedef struct {
+  size_t count;
+  size_t backoff;
+} coz_counter_t;
+
+/* Counter types, matching include/coz.h. */
+#define COZ_SHIM_THROUGHPUT 1
+#define COZ_SHIM_BEGIN 2
+#define COZ_SHIM_END 3
+
+/* Resolve _coz_get_counter/_coz_add_delays from the injected libcoz. Idempotent
+ * but not thread-safe; callers must serialize (the Go side uses sync.Once). */
+void coz_shim_init(void);
+
+/* Non-zero if libcoz was found, i.e. the program is running under `coz run`. */
+int coz_shim_available(void);
+
+/* Returns libcoz's counter for (type, name), or NULL if not profiling. */
+coz_counter_t* coz_shim_get_counter(int type, const char* name);
+
+/* Calls _coz_add_delays() if available. See checkDelays() in the Go sources for
+ * why this is only invoked on macOS. */
+void coz_shim_add_delays(void);
+
+#endif /* COZ_GO_SHIM_H */

--- a/go/coz_test.go
+++ b/go/coz_test.go
@@ -1,0 +1,76 @@
+//go:build cgo
+
+package coz
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// When libcoz is absent (the normal `go test` case) every entry point must be a
+// safe no-op rather than a nil dereference.
+func TestNoProfilerIsNoOp(t *testing.T) {
+	if Available() {
+		t.Skip("running under `coz run`; this test covers the un-profiled path")
+	}
+
+	Progress()
+	ProgressNamed("named")
+	Begin("op")
+	End("op")
+	Scope("scoped")()
+
+	NewThroughput("t").Increment()
+	NewBegin("b").Increment()
+	NewEnd("e").Increment()
+}
+
+func TestNilCounterIncrementIsSafe(t *testing.T) {
+	var c *Counter
+	c.Increment()            // nil receiver
+	(&Counter{}).Increment() // zero value, no underlying libcoz counter
+}
+
+// Counters are memoized, so the same name must yield the same handle.
+func TestCounterCacheReturnsSameInstance(t *testing.T) {
+	a := cachedCounter(counterThroughput, "dup")
+	b := cachedCounter(counterThroughput, "dup")
+	if a != b {
+		t.Errorf("cachedCounter returned distinct handles for the same name")
+	}
+
+	// Same name, different counter type, must not collide.
+	if got := cachedCounter(counterBegin, "dup"); got == a {
+		t.Errorf("throughput and begin counters collided in the cache")
+	}
+}
+
+func TestCallSiteNameIsFileAndLine(t *testing.T) {
+	pc, _, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	name := callSiteName(pc)
+	if !strings.Contains(name, "coz_test.go:") {
+		t.Errorf("callSiteName(%#x) = %q, want it to mention coz_test.go:<line>", pc, name)
+	}
+}
+
+func TestConcurrentIncrementsDoNotRace(t *testing.T) {
+	// Exercised under `go test -race`; without libcoz these are no-ops, but the
+	// cache and sync.Once paths are still hit from many goroutines.
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				ProgressNamed("concurrent")
+				Scope("concurrent-scope")()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/go/delays_darwin.go
+++ b/go/delays_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin && cgo
+
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+package coz
+
+/*
+#include "coz_shim.h"
+*/
+import "C"
+
+// checkDelays makes this thread pay any virtual delay it owes the profiler.
+//
+// macOS has no per-thread sampling timer, so a worker thread only discovers its
+// delay debt when it reaches a progress point. This mirrors the __APPLE__ arm
+// of _COZ_CHECK_DELAYS in include/coz.h.
+func checkDelays() { C.coz_shim_add_delays() }

--- a/go/delays_other.go
+++ b/go/delays_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin && cgo
+
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+package coz
+
+// checkDelays is a no-op off macOS.
+//
+// On Linux the SIGPROF handler already applies delays via process_samples(), so
+// calling _coz_add_delays() again at every progress point would apply them
+// twice and collapse throughput under concurrency. This mirrors the non-Apple
+// arm of _COZ_CHECK_DELAYS in include/coz.h.
+func checkDelays() {}

--- a/go/example/toy.go
+++ b/go/example/toy.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+// Command toy is the Go port of benchmarks/toy: two goroutines do unequal
+// amounts of work, and a progress point marks each completed round.
+//
+// slowWork does twice the work of fastWork, so it sits on the critical path.
+// A correct causal profile predicts a large speedup for the loop inside
+// slowWork and almost none for the one inside fastWork.
+//
+//	go build -o toy ./example
+//	coz run --- ./toy
+//	coz plot --text
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	coz "github.com/plasma-umass/coz/go"
+)
+
+const iterations = 100_000_000
+
+// Accumulate into package-level variables so the compiler cannot delete the
+// loops. Each goroutine writes its own, so there is no race.
+var slowSink, fastSink uint64
+
+func slowWork() {
+	for i := uint64(0); i < iterations; i++ {
+		slowSink += i
+	}
+}
+
+func fastWork() {
+	for i := uint64(0); i < iterations/2; i++ {
+		fastSink += i
+	}
+}
+
+func main() {
+	fmt.Println("Starting.")
+
+	for round := 0; round < 100; round++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); slowWork() }()
+		go func() { defer wg.Done(); fastWork() }()
+		wg.Wait()
+
+		// One round of work finished: this is the throughput progress point.
+		coz.Progress()
+
+		fmt.Print(".")
+	}
+
+	fmt.Printf("\nDone. %d %d\n", slowSink, fastSink)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/plasma-umass/coz/go
+
+go 1.21

--- a/libcoz/profiler.cpp
+++ b/libcoz/profiler.cpp
@@ -111,10 +111,19 @@ void profiler::startup(const string& outfile,
   // Set up the sampling signal handler.
   // On macOS, use the __asm-bound original sigaction to bypass our own
   // DYLD interposition which blocks setting handlers for coz's signals.
+  // SA_ONSTACK runs the handler on the thread's alternate signal stack when it
+  // has one. Managed runtimes give each thread a small, movable stack and set
+  // up an altstack precisely so that foreign signal handlers stay off it -- Go
+  // documents this as a requirement for any non-Go handler, and without it a Go
+  // program crashes once coz samples a thread that is running a goroutine.
+  // (Go only trips this when cgo is in play: an `iscgo` runtime creates its Ms
+  // with pthread_create, which coz interposes and gives a perf event.)
+  // Threads with no altstack ignore the flag and use the normal stack, so this
+  // is inert for ordinary C/C++ programs.
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = profiler::samples_ready;
-  sa.sa_flags = SA_SIGINFO;
+  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
 #ifdef __APPLE__
   coz_orig_sigaction(SampleSignal, &sa, nullptr);
 #else
@@ -124,7 +133,7 @@ void profiler::startup(const string& outfile,
   // Set up handlers for errors
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = on_error;
-  sa.sa_flags = SA_SIGINFO;
+  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
 
 #ifdef __APPLE__
   coz_orig_sigaction(SIGSEGV, &sa, nullptr);


### PR DESCRIPTION
Adds a `go/` module exposing coz's progress points to Go, plus the one `libcoz` change needed to make Go programs safe to profile at all.

> Stacked on #286 (the Rust/macOS signal fix). Base will retarget to `master` once that merges; review this diff for the `go/` module and the `SA_ONSTACK` change.

## The binding

Resolves `_coz_get_counter` / `_coz_add_delays` out of the injected libcoz via `dlsym(RTLD_DEFAULT, ...)`, the same approach as the Rust crate. Consequences:

- No `coz.h` needed at build time, and no system `coz-profiler` package (unlike [cozgo](https://github.com/urjitbhatia/cozgo), which `#include <coz.h>` and requires it installed).
- A binary built against it runs normally when libcoz is absent — every entry point degrades to a no-op.
- The counter bump is a relaxed atomic performed *from Go* on libcoz-owned memory, so there is **no cgo call on the hot path** on Linux.
- `_coz_add_delays()` is gated to macOS, mirroring `_COZ_CHECK_DELAYS` in `include/coz.h` (calling it per progress point on Linux double-applies delays).

API: `Progress`, `ProgressNamed`, `Begin`, `End`, `Scope` (defer-friendly latency pair), and `NewThroughput`/`NewBegin`/`NewEnd` to hoist the lookup out of a hot loop. `Progress()` names its point after the caller's `file:line` via `runtime.Caller`, so it behaves like `COZ_PROGRESS` instead of reporting a line inside the binding.

With `CGO_ENABLED=0` the package builds as no-ops rather than failing, so progress points can stay in code that also ships as a static binary.

## The libcoz change: `SA_ONSTACK`

This is the interesting part. **Every Go program with cgo enabled segfaults partway through a `coz run`** without it.

When `iscgo` is set, the Go runtime creates its Ms with `pthread_create` rather than raw `clone()`. coz interposes `pthread_create`, so it registers those threads, gives each a perf event, and delivers SIGPROF to them — while they are running **goroutine stacks**, which are small and movable. Go's cgo documentation requires foreign signal handlers to set `SA_ONSTACK` for precisely this reason.

Isolation that pinned it down (Linux arm64):

| case | crash | experiments |
|---|---|---|
| C benchmark (`benchmarks/toy`) | no | 11 |
| bare Go, no cgo, no coz | no | 0 (creates threads with `clone`, coz never sees them) |
| Go toy (cgo + coz), before fix | **yes** | — |
| Go toy, `GOMAXPROCS=1`, before fix | no | — (few extra Ms) |
| Go toy, after fix | no | 8–10 |

Threads with no alternate signal stack ignore the flag and use the normal stack, so this is inert for ordinary C/C++ programs — the C toy is unchanged at 11 experiments before and after, and the macOS C/Rust paths are unaffected.

## Verification

Both platforms, end to end, with `go/example/toy.go` (two goroutines per round; `slowWork` does twice the work of `fastWork`, so it is on the critical path):

**macOS arm64** — 11 experiments:
```
/go/example/toy.go:35  slope 0.758  R² 0.99  max +70.7%   <- slowWork
/go/example/toy.go:40  slope   N/A  R²  N/A  max  +0.0%
```

**Linux arm64** (Ubuntu 24.04 container, Go 1.26.5) — 3/3 runs clean, 8–10 experiments:
```
/src/go/example/toy.go:35  slope 0.571  R² 0.87  max +42.0%   <- slowWork
/src/go/example/toy.go:41  slope 0.165  R² 1.00  max +15.7%   <- fastWork
```

Coz correctly predicts that speeding up `slowWork` speeds up the program roughly proportionally, and that `fastWork` is nearly irrelevant. `go test -race` passes; `go vet` and `gofmt` clean; builds verified with both `CGO_ENABLED=1` and `CGO_ENABLED=0`.

## Documented caveats (in `go/README.md`)

- **`-ldflags=-compressdwarf=false` is required.** Go's linker emits compressed DWARF (`.zdebug_*` / `__zdebug_*`) and coz only reads `__debug_*`, so without it coz reports "Debug information was not found."
- **Don't run `runtime/pprof` CPU profiling concurrently** — both want SIGPROF.
- **Results are per-OS-thread, not per-goroutine**, since coz's virtual speedup delays threads.
- **On Linux `coz plot` shows `Runtime: 0.0s`** for Go programs: Go exits via a direct `exit_group` syscall, so coz's shutdown hook never writes the final `runtime` record. Experiment records are flushed as they complete, so the profile itself is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)