### PR TITLE
Fix SIGBUS from under-aligned profiler singleton on aarch64

### DIFF
--- a/libcoz/profiler.h
+++ b/libcoz/profiler.h
@@ -223,7 +223,11 @@ public:
 
   /// Only allow one instance of the profiler, and never run the destructor
   static profiler& get_instance() {
-    static char buf[sizeof(profiler)];
+    // alignas is required, not decorative: a bare `char buf[]` has alignment 1,
+    // so placement-newing a profiler into it can leave the std::atomic members
+    // under-aligned. x86 tolerates that; aarch64 raises SIGBUS on the first
+    // atomic store in the constructor.
+    alignas(profiler) static char buf[sizeof(profiler)];
     static profiler* p = new(buf) profiler();
     return *p;
   }


### PR DESCRIPTION
`profiler::get_instance()` placement-news the profiler into a plain `char` buffer:

```cpp
static char buf[sizeof(profiler)];
static profiler* p = new(buf) profiler();
```

`char buf[]` has alignment 1, so nothing guarantees the buffer satisfies `alignof(profiler)`. The profiler holds several `std::atomic<size_t>` members and its constructor stores to all of them. x86 tolerates an under-aligned atomic; **aarch64 traps.**

## Symptom

On aarch64 Linux this kills every Swift binary before `main`:

```
*** Program crashed: Bus error at 0x0000ffff89a6944d ***
Thread 0 crashed:
0 [inlined] std::__atomic_base<unsigned long>::store(...)  atomic_base.h:481
1           profiler::profiler()                           libcoz/profiler.h:235
2 [ra]      init_coz()                                     libcoz/profiler.h:227
3 [ra]      wrapped_main(int, char**, char**)              libcoz/libcoz.cpp:284
```

I found this while adding Swift bindings, but it is **not Swift-specific and not binding-specific**: a bare Swift program that never links, imports, or references coz crashes identically under `coz run`. The bug is latent for every target; whether it fires depends on where the linker happens to place `buf`, and the memory layout Swift's runtime produces exposes it.

## Fix

`alignas(profiler)` on the buffer. One line, no behavior change otherwise.

## Verification (aarch64, Ubuntu 24.04 / Swift 6.1.3 containers)

| | before | after |
|---|---|---|
| bare Swift binary under `coz run` | SIGBUS before `main` | runs clean |
| Swift toy under `coz run` | SIGBUS, no profile | rc=0, 10 experiments, profile written |
| C toy (`benchmarks/toy`) | 11 experiments | 11 experiments (unaffected) |

Also re-verified on macOS arm64: the C, Rust, and Go toys all still profile correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)