### PR TITLE
Add a JVMTI agent for causal profiling of Java

### DIFF
--- a/.github/scripts/check_profile.py
+++ b/.github/scripts/check_profile.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Assert that a coz profile contains experiments attributed to a source file.
+
+Usage: check_profile.py <profile.jsonl> <expected-source-substring>
+
+Used by the per-language CI jobs. A binding is only "working" if libcoz both
+registered its progress points and attributed experiments back to that
+language's source, so this checks for experiment records naming the file.
+"""
+import collections
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <profile.jsonl> <expected-source-substring>")
+        return 2
+
+    path, expected = sys.argv[1], sys.argv[2]
+
+    records = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    kinds = collections.Counter(r["type"] for r in records)
+    print(f"record types: {dict(kinds)}")
+
+    experiments = [r for r in records if r["type"] == "experiment"]
+    if not experiments:
+        print("ERROR: profile contains no experiments")
+        return 1
+
+    matching = [e for e in experiments if expected in e.get("selected", "")]
+    selected = collections.Counter(e.get("selected", "") for e in experiments)
+    print(f"experiments: {len(experiments)} ({len(matching)} naming {expected!r})")
+    for location, count in selected.most_common(10):
+        print(f"  {count:4d}  {location}")
+
+    if not matching:
+        print(f"ERROR: no experiment selected a line in {expected!r}")
+        return 1
+
+    print(f"OK: {len(matching)} experiments attributed to {expected!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,58 @@ jobs:
         fi
         echo "Profile created:"
         cat profile.jsonl
+
+  lang-java:
+    name: Java agent (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Temurin, not GraalVM: the agent samples at safepoints, and the Graal JIT
+    # leaves hot counted loops without a safepoint poll, pushing the mean
+    # time-to-safepoint from ~100us to ~100ms. See java/README.md.
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake pkg-config
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install pkg-config coreutils || true
+
+    - name: Build the agent and coz.jar
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_JAVA_AGENT=ON
+        cmake --build build --target cozjava coz-jar -j3
+        test -f build/java/libcozjava.so
+        test -f build/java/coz.jar
+
+    - name: Build the Java toy
+      working-directory: java
+      run: |
+        mkdir -p "$RUNNER_TEMP/classes"
+        # -g keeps the line tables the agent reads through GetLineNumberTable.
+        javac -g -cp ../build/java/coz.jar -d "$RUNNER_TEMP/classes" example/Toy.java
+
+    - name: Profile the Java toy under the agent
+      run: |
+        TIMEOUT=timeout
+        command -v gtimeout >/dev/null && TIMEOUT=gtimeout
+        $TIMEOUT 240 java \
+          -agentpath:"$PWD/build/java/libcozjava.so=output=$PWD/profile.jsonl,scope=example,verbose=1" \
+          -cp "$RUNNER_TEMP/classes:$PWD/build/java/coz.jar" example.Toy || true
+        test -s profile.jsonl
+
+    - name: Validate the Java profile
+      run: python3 .github/scripts/check_profile.py profile.jsonl Toy.java

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,14 @@ endif()
 
 add_subdirectory(libcoz)
 
+# The JVMTI agent is independent of libcoz: JIT-compiled Java frames carry no
+# DWARF, so it does its own sampling and virtual speedup. Off by default because
+# it needs a JDK.
+option(BUILD_JAVA_AGENT "Build the coz JVMTI agent for profiling Java" OFF)
+if(BUILD_JAVA_AGENT)
+    add_subdirectory(java)
+endif()
+
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 if(BUILD_BENCHMARKS)
     if(NOT CMAKE_BUILD_TYPE)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,0 +1,77 @@
+# The coz JVMTI agent, plus the coz.Coz progress-point API it binds natives to.
+#
+# Built only when a JDK is available. Enable with -DBUILD_JAVA_AGENT=ON.
+
+find_package(JNI)
+find_package(Java COMPONENTS Development)
+
+if(NOT JNI_FOUND)
+  message(WARNING "BUILD_JAVA_AGENT is ON but no JDK was found; skipping the Java agent")
+  return()
+endif()
+
+# jvmti.h sits beside jni.h in the JDK's include directory. find_package(JNI)
+# reports that directory, but only some CMake versions put it in JNI_INCLUDE_DIRS,
+# so derive it from jni.h's location as well.
+find_path(JVMTI_INCLUDE_DIR
+  NAMES jvmti.h
+  HINTS ${JAVA_INCLUDE_PATH} ${JNI_INCLUDE_DIRS}
+)
+
+if(NOT JVMTI_INCLUDE_DIR)
+  message(WARNING "jvmti.h not found next to jni.h; skipping the Java agent")
+  return()
+endif()
+
+# A JVMTI agent is dlopen'd by the JVM, so it is a MODULE, like libcoz itself.
+add_library(cozjava MODULE agent/coz_agent.cpp)
+
+target_include_directories(cozjava PRIVATE
+  ${JNI_INCLUDE_DIRS}
+  ${JVMTI_INCLUDE_DIR}
+)
+
+target_compile_features(cozjava PRIVATE cxx_std_14)
+
+set_target_properties(cozjava PROPERTIES
+  # `java -agentpath:` wants a plain path, and the JVM does not care about the
+  # extension, but keep the platform-conventional one.
+  PREFIX "lib"
+)
+
+if(THREADS_FOUND)
+  target_link_libraries(cozjava PRIVATE Threads::Threads)
+endif()
+
+if(INSTALL_COZ)
+  install(TARGETS cozjava LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/coz-profiler)
+endif()
+
+# ---------------------------------------------------------------------------
+# coz.jar -- the Java-side API. Optional: the agent is useless without it, but
+# a project can equally compile src/coz/Coz.java into its own build.
+# ---------------------------------------------------------------------------
+if(Java_JAVAC_EXECUTABLE AND Java_JAR_EXECUTABLE)
+  set(COZ_JAR "${CMAKE_CURRENT_BINARY_DIR}/coz.jar")
+  set(COZ_CLASSES "${CMAKE_CURRENT_BINARY_DIR}/classes")
+
+  add_custom_command(
+    OUTPUT ${COZ_JAR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${COZ_CLASSES}
+    # -g keeps the line tables the agent reads back through GetLineNumberTable.
+    COMMAND ${Java_JAVAC_EXECUTABLE} -g -d ${COZ_CLASSES}
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/coz/Coz.java
+    COMMAND ${Java_JAR_EXECUTABLE} cf ${COZ_JAR} -C ${COZ_CLASSES} coz
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/coz/Coz.java
+    COMMENT "Building coz.jar"
+    VERBATIM
+  )
+
+  add_custom_target(coz-jar ALL DEPENDS ${COZ_JAR})
+
+  if(INSTALL_COZ)
+    install(FILES ${COZ_JAR} DESTINATION ${CMAKE_INSTALL_DATADIR}/coz-profiler)
+  endif()
+else()
+  message(STATUS "javac/jar not found; building the agent but not coz.jar")
+endif()

--- a/java/README.md
+++ b/java/README.md
@@ -123,12 +123,26 @@ C2. `verbose=1` prints the mean time-to-safepoint so you can check:
 
 If that number is in the milliseconds, your profile is not trustworthy.
 
-**Sampling is safepoint-biased.** A sample lands on the last safepoint poll the
-thread passed, not on the instruction it was executing. In a hot loop with a poll
-per strip, that is close enough to attribute the loop. In a loop with no poll at
-all, every sample lands on the line *after* the loop. This is the price of using
-documented JVMTI instead of `AsyncGetCallTrace`; it is the same reason most
-Java sampling profilers report method-level rather than line-level truth.
+**Sampling is safepoint-biased, so this is not line-level attribution.** A
+sample lands on the last safepoint poll the thread passed, not on the instruction
+it was executing. Measured on `example/Toy.java` under HotSpot C2:
+
+| line | source | samples |
+|---|---|---|
+| 47 | `for (int i = 0; i < ITERATIONS; i++) {` | **1666** |
+| 48 | `acc = xorshift(acc);` — the actual work | **0** |
+
+Every sample landed on the loop header, where the strip-mined back-edge poll
+sits, and none on the line doing the work. Read a coz-java profile as pointing at
+*the loop or method* that matters, not the statement. (The 1666:944 split between
+the two loops also misses their true 2:1 work ratio by about 12%.)
+
+This is the price of using documented JVMTI instead of `AsyncGetCallTrace`, which
+walks the stack from a signal handler and does not need a safepoint.
+`AsyncGetCallTrace` is exported from `libjvm` on HotSpot and GraalVM, but it is
+undocumented, appears in no specification, is absent from non-HotSpot VMs, and
+must be driven from per-thread CPU timers that macOS does not provide. Making it
+an opt-in sampler is the obvious next step; it is not the safe default.
 
 **Compile with `-g`.** Without line tables the agent cannot map a bytecode index
 to a line, and the class is silently skipped. `javac -g` is enough.

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,158 @@
+# coz-java
+
+Java support for the [`coz` causal profiler](https://github.com/plasma-umass/coz),
+as a JVMTI agent.
+
+A traditional profiler tells you *where* your program spends time. Coz tells you
+whether optimizing a line would actually make the program faster — which, in
+concurrent code, is a different question.
+
+Works on **Linux** and **macOS**.
+
+## Why this is an agent and not a binding
+
+The Rust, Go and Swift bindings are thin: they hand their progress points to
+`libcoz` and let it do the work. `libcoz` samples the program counter, maps it to
+a source line through DWARF, and inserts virtual delays by pausing native threads.
+
+None of that survives contact with the JVM. Java methods are compiled at run time
+into anonymous memory with no DWARF, so a sampled PC maps to nothing, and the
+threads to delay are Java threads `libcoz` has never heard of. So this agent
+reimplements the causal profiling loop in JVM terms:
+
+- **Sampling.** Every sample period it asks JVMTI for the top frame of every Java
+  thread (`GetAllStackTraces`) and resolves it to a source line with
+  `GetLineNumberTable`. [JCoz](https://github.com/Decave/JCoz) instead used
+  `AsyncGetCallTrace`, a private, undocumented HotSpot entry point.
+  `GetAllStackTraces` is specified, stable, and works on every JDK and both
+  platforms — at the cost of the safepoint caveat below.
+- **Virtual speedup.** To pretend one line runs faster, the agent slows
+  everything else down: for each sample on the selected line it owes every *other*
+  thread a pause of `speedup × sample_period`, paid with
+  `SuspendThreadList`/`ResumeThreadList`, batched so the VM reaches a safepoint
+  once per batch rather than once per sample.
+- **Progress points.** `coz.Coz.progress()` and friends bump a counter; the delta
+  across an experiment is the throughput measurement.
+
+Output is coz's own JSON Lines profile, so `coz plot` reads it unchanged.
+
+## Building
+
+```
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_JAVA_AGENT=ON
+cmake --build build --target cozjava coz-jar
+```
+
+This produces `build/java/libcozjava.so` (the agent; also `.so` on macOS, since
+the JVM does not care about the extension) and `build/java/coz.jar` (the API).
+
+## Usage
+
+Compile with `-g` so the class files carry the line tables the agent reads back:
+
+```
+javac -g -cp build/java/coz.jar -d classes MyApp.java
+```
+
+Mark the points where your program makes progress:
+
+```java
+import coz.Coz;
+
+for (Request request : requests) {
+    handle(request);
+    Coz.progress("requests");     // equivalent of COZ_PROGRESS_NAMED
+}
+```
+
+`Coz.progress()` with no argument names the point after the call site. For
+latency, `Coz.begin("request")` / `Coz.end("request")`, or
+`Coz.scope("request", () -> handle(request))`, which ends even if the body throws.
+
+Then run under the agent and plot:
+
+```
+java -agentpath:build/java/libcozjava.so=output=profile.jsonl,scope=com.example \
+     -cp classes:build/java/coz.jar com.example.MyApp
+
+coz plot --text -i profile.jsonl
+```
+
+Agent options, comma-separated after `=`:
+
+| option | default | meaning |
+|---|---|---|
+| `output` | `profile.jsonl` | where to write the profile |
+| `scope` | application classes | only profile this package prefix (`com.example`) |
+| `period` | `5000000` | nanoseconds between samples |
+| `verbose` | off | log startup, sample count, mean time-to-safepoint |
+
+Without the agent, every `Coz` method is a no-op, so instrumented code runs
+normally in production.
+
+## Example
+
+`example/Toy.java` runs two threads per round; `slowWork` does twice the work of
+`fastWork`, so it sits on the critical path.
+
+```
+Source Line         |   Slope |    R² | Max Speedup | Points
+--------------------+---------+-------+-------------+-------
+example/Toy.java:47 |   0.496 |  1.00 | +     41.3% |     3
+example/Toy.java:55 |   0.090 |  0.21 | +     14.1% |     9
+```
+
+Line 47 is `slowWork`'s loop and line 55 is `fastWork`'s. Coz predicts that
+speeding up `slowWork` speeds up the program roughly proportionally, and finds
+`fastWork` nearly irrelevant.
+
+## Caveats
+
+**Do not profile on GraalVM's JIT.** The agent samples at safepoints, so its
+sample rate is bounded by the VM's time-to-safepoint. Under HotSpot's C2 that is
+about **100µs**. Under the Graal JIT it was about **100ms** on the toy above —
+a thousand times worse, because Graal left no safepoint poll in the hot counted
+loop. The agent then samples ~10 times a second and cannot attribute anything.
+
+Run on a HotSpot JDK, or on GraalVM pass `-XX:-UseJVMCICompiler` to fall back to
+C2. `verbose=1` prints the mean time-to-safepoint so you can check:
+
+```
+[coz-java] wrote profile.jsonl (1671 sample ticks, mean GetAllStackTraces 147 us)
+```
+
+If that number is in the milliseconds, your profile is not trustworthy.
+
+**Sampling is safepoint-biased.** A sample lands on the last safepoint poll the
+thread passed, not on the instruction it was executing. In a hot loop with a poll
+per strip, that is close enough to attribute the loop. In a loop with no poll at
+all, every sample lands on the line *after* the loop. This is the price of using
+documented JVMTI instead of `AsyncGetCallTrace`; it is the same reason most
+Java sampling profilers report method-level rather than line-level truth.
+
+**Compile with `-g`.** Without line tables the agent cannot map a bytecode index
+to a line, and the class is silently skipped. `javac -g` is enough.
+
+**Use `scope=`.** Without it, the agent profiles everything that is not the JDK,
+which for a large application means resolving line tables for a lot of classes it
+will never select.
+
+**`coz plot` charts throughput points only.** `begin`/`end` counters are recorded
+in the profile as `latency-point` records, but the plot reader currently consumes
+only `throughput-point`.
+
+**Suspending threads costs.** Virtual speedup is implemented by actually pausing
+threads, so a profiled run is slower than an unprofiled one. On the toy the
+overhead is roughly 10%.
+
+## JDK support
+
+The agent uses only documented JVMTI 1.2: `GetAllStackTraces`,
+`GetLineNumberTable`, `GetSourceFileName`, `SuspendThreadList`,
+`ResumeThreadList`, `RunAgentThread`, `RegisterNatives`. It needs no `tools.jar`
+(removed in JDK 9), no `AsyncGetCallTrace`, and no dynamic agent attach, so
+[JEP 451](https://openjdk.org/jeps/451) does not apply — it loads statically with
+`-agentpath`.
+
+Verified on JDK 17 (Temurin, macOS arm64) and JDK 21 (Ubuntu, Linux aarch64).
+JDK 25 is the current LTS and uses the same JVMTI surface.

--- a/java/agent/coz_agent.cpp
+++ b/java/agent/coz_agent.cpp
@@ -1,0 +1,758 @@
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ *
+ * A JVMTI agent that performs causal profiling of Java code.
+ *
+ * Why this is not just a binding
+ * ------------------------------
+ * The Rust, Go and Swift bindings hand their progress points to libcoz and let
+ * it do the work: libcoz samples the program counter, maps it to a source line
+ * through DWARF, and inserts virtual delays by pausing native threads. None of
+ * that survives contact with the JVM. Java methods are compiled at run time
+ * into anonymous memory with no DWARF, so a sampled PC maps to nothing, and
+ * the threads to delay are Java threads that libcoz has never heard of.
+ *
+ * So this agent reimplements the causal profiling loop in JVM terms:
+ *
+ *   - Sampling. Every sample period the agent asks JVMTI for the top frame of
+ *     every Java thread (GetAllStackTraces) and resolves it to a source line
+ *     with GetLineNumberTable. JCoz instead used AsyncGetCallTrace, a private,
+ *     undocumented HotSpot entry point; GetAllStackTraces is specified, stable
+ *     and works on every JDK and both platforms.
+ *
+ *   - Virtual speedup. To pretend that one line runs faster, the agent slows
+ *     everything else down: for each sample that landed on the selected line,
+ *     it owes every *other* thread a pause of `speedup * sample_period`. It
+ *     pays that debt with SuspendThreadList / ResumeThreadList, batched so the
+ *     JVM only reaches a safepoint once per batch rather than once per sample.
+ *
+ *   - Progress points. coz.Coz.progress()/begin()/end() land in the natives
+ *     below and bump a counter. The experiment loop reads the counters before
+ *     and after each experiment; the delta is the throughput measurement.
+ *
+ * Output is coz's own JSON Lines profile, so `coz plot` reads it unchanged.
+ *
+ * Locking discipline
+ * ------------------
+ * The agent suspends Java threads while they are at arbitrary points in their
+ * execution. If a suspended thread held a lock that the agent then tried to
+ * take, the agent would deadlock the whole VM. So no lock is ever shared with
+ * a Java thread: the progress-point registry is an append-only, lock-free list
+ * that Java threads only ever push onto and the agent only ever walks. Every
+ * other data structure here is touched by the agent thread alone.
+ */
+
+#include <jni.h>
+#include <jvmti.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Tunables, mirroring libcoz/profiler.h
+// ---------------------------------------------------------------------------
+
+/// Nanoseconds between samples. Each sample is a GetAllStackTraces call, which
+/// brings the VM to a safepoint, so this is far more expensive than libcoz's
+/// 1ms PC sample. 5ms keeps overhead tolerable while still collecting enough
+/// samples to pick a line.
+constexpr int64_t kDefaultSamplePeriod = 5'000'000;
+
+/// Samples per delay batch. Delays are accumulated across a batch and paid in
+/// one suspend/resume round, so the VM reaches a safepoint for delay insertion
+/// once per batch instead of once per sample.
+constexpr int kSampleBatchSize = 10;
+
+/// Virtual speedups are chosen from {0/20, 1/20, ... 20/20}.
+constexpr int kSpeedupDivisions = 20;
+
+/// Extra weight given to the 0% baseline, so roughly half of all experiments
+/// measure the un-sped-up program.
+constexpr int kZeroSpeedupWeight = 7;
+
+/// Minimum wall time for one experiment.
+constexpr int64_t kExperimentMinTime = 500'000'000;
+
+/// Idle time between experiments, letting the previous speedup wash out.
+constexpr int64_t kExperimentCoolOff = 100'000'000;
+
+/// An experiment is only worth recording if every progress point advanced at
+/// least this much; otherwise the throughput estimate is noise.
+constexpr int64_t kExperimentTargetDelta = 5;
+
+/// Give up extending an experiment after this long, even if the progress point
+/// never reaches kExperimentTargetDelta. Without this a program whose progress
+/// point stops firing would hang the experiment loop until VM death.
+constexpr int64_t kExperimentMaxTime = 5'000'000'000;
+
+// ---------------------------------------------------------------------------
+// Progress points: an append-only, lock-free list
+// ---------------------------------------------------------------------------
+
+enum CounterKind { kThroughput = 1, kBegin = 2, kEnd = 3 };
+
+struct ProgressPoint {
+  std::string name;
+  CounterKind kind;
+  std::atomic<int64_t> count{0};
+  ProgressPoint* next = nullptr;
+
+  ProgressPoint(std::string n, CounterKind k) : name(std::move(n)), kind(k) {}
+};
+
+std::atomic<ProgressPoint*> g_points{nullptr};
+
+/// Find or create the counter for (name, kind).
+///
+/// Called from Java threads. Racing creators may both allocate; the loser's
+/// node is dropped and the winner's returned, so a given (name, kind) always
+/// resolves to one counter. Nodes are never freed -- the list lives as long as
+/// the VM, and freeing would race with the agent walking it.
+ProgressPoint* find_or_create(const char* name, CounterKind kind) {
+  for (;;) {
+    ProgressPoint* head = g_points.load(std::memory_order_acquire);
+    for (ProgressPoint* p = head; p != nullptr; p = p->next) {
+      if (p->kind == kind && p->name == name) return p;
+    }
+
+    auto* fresh = new ProgressPoint(name, kind);
+    fresh->next = head;
+    if (g_points.compare_exchange_weak(head, fresh, std::memory_order_release,
+                                       std::memory_order_relaxed)) {
+      return fresh;
+    }
+    // Someone else pushed first: drop ours and rescan, in case they added the
+    // very point we wanted.
+    delete fresh;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent state (agent thread only, unless noted)
+// ---------------------------------------------------------------------------
+
+struct Options {
+  std::string output = "profile.jsonl";
+  std::string scope;  // package prefix, in internal form ("com/example")
+  int64_t sample_period = kDefaultSamplePeriod;
+  bool verbose = false;
+};
+
+Options g_options;
+jvmtiEnv* g_jvmti = nullptr;
+JavaVM* g_vm = nullptr;
+
+std::atomic<bool> g_running{false};
+
+/// The agent's own sampling thread, which must never suspend itself.
+jthread g_agent_thread = nullptr;
+
+/// Total samples seen per source line, for the `samples` records.
+std::map<std::string, int64_t> g_samples;
+
+/// Diagnostics for --verbose: how many times we sampled, and how long the VM
+/// took to reach a safepoint for it.
+int64_t g_ticks = 0;
+int64_t g_sample_ns = 0;
+
+int64_t now_ns() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+void sleep_ns(int64_t ns) {
+  if (ns > 0) std::this_thread::sleep_for(std::chrono::nanoseconds(ns));
+}
+
+template <typename T>
+void deallocate(T* p) {
+  if (p != nullptr) g_jvmti->Deallocate(reinterpret_cast<unsigned char*>(p));
+}
+
+// ---------------------------------------------------------------------------
+// Line resolution
+// ---------------------------------------------------------------------------
+
+/// Cache of jmethodID -> (source path, line table). Agent thread only.
+struct MethodInfo {
+  bool in_scope = false;
+  std::string source;  // "com/example/Toy.java"
+  std::vector<jvmtiLineNumberEntry> lines;
+};
+
+std::map<jmethodID, MethodInfo> g_methods;
+
+/// Turn "Lcom/example/Toy;" plus "Toy.java" into "com/example/Toy.java", which
+/// is what a `coz plot` reader expects a source location to look like.
+std::string source_path(const std::string& class_signature, const char* file) {
+  std::string internal = class_signature;
+  if (internal.size() > 2 && internal.front() == 'L' && internal.back() == ';') {
+    internal = internal.substr(1, internal.size() - 2);
+  }
+  // Nested classes (Outer$Inner) share the outer class's source file.
+  const size_t slash = internal.rfind('/');
+  const std::string package = (slash == std::string::npos) ? "" : internal.substr(0, slash + 1);
+  return package + (file != nullptr ? file : "Unknown");
+}
+
+/// True if a class is application code rather than the runtime or a profiler.
+bool in_scope(const std::string& class_signature) {
+  const std::string internal =
+      (class_signature.size() > 2 && class_signature.front() == 'L')
+          ? class_signature.substr(1, class_signature.size() - 2)
+          : class_signature;
+
+  if (!g_options.scope.empty()) {
+    return internal.compare(0, g_options.scope.size(), g_options.scope) == 0;
+  }
+
+  // No explicit scope: everything except the runtime and coz itself.
+  static const char* const kExcluded[] = {"java/", "javax/", "jdk/",  "sun/",
+                                          "com/sun/", "kotlin/", "scala/", "coz/"};
+  for (const char* prefix : kExcluded) {
+    if (internal.compare(0, strlen(prefix), prefix) == 0) return false;
+  }
+  return true;
+}
+
+const MethodInfo* method_info(jmethodID method) {
+  auto it = g_methods.find(method);
+  if (it != g_methods.end()) return &it->second;
+
+  MethodInfo info;
+
+  jclass declaring = nullptr;
+  if (g_jvmti->GetMethodDeclaringClass(method, &declaring) != JVMTI_ERROR_NONE) {
+    g_methods[method] = info;
+    return &g_methods[method];
+  }
+
+  char* signature = nullptr;
+  if (g_jvmti->GetClassSignature(declaring, &signature, nullptr) == JVMTI_ERROR_NONE &&
+      signature != nullptr) {
+    if (in_scope(signature)) {
+      char* file = nullptr;
+      // Classes compiled without -g:source have no source file name; such a
+      // method can never be attributed to a line, so it stays out of scope.
+      if (g_jvmti->GetSourceFileName(declaring, &file) == JVMTI_ERROR_NONE && file != nullptr) {
+        jint count = 0;
+        jvmtiLineNumberEntry* table = nullptr;
+        // Likewise for -g:lines. Native and abstract methods return
+        // JVMTI_ERROR_NATIVE_METHOD / ABSENT_INFORMATION here.
+        if (g_jvmti->GetLineNumberTable(method, &count, &table) == JVMTI_ERROR_NONE) {
+          info.in_scope = true;
+          info.source = source_path(signature, file);
+          info.lines.assign(table, table + count);
+          deallocate(table);
+        }
+        deallocate(file);
+      }
+    }
+    deallocate(signature);
+  }
+
+  g_methods[method] = std::move(info);
+  return &g_methods[method];
+}
+
+/// Resolve a (method, bytecode index) to "com/example/Toy.java:42", or "" if
+/// the method is out of scope or carries no line information.
+std::string resolve_line(jmethodID method, jlocation location) {
+  const MethodInfo* info = method_info(method);
+  if (info == nullptr || !info->in_scope || info->lines.empty()) return "";
+
+  // The line table maps a starting bytecode index to a line; the applicable
+  // entry is the last one at or before this location.
+  jint line = info->lines.front().line_number;
+  for (const auto& entry : info->lines) {
+    if (entry.start_location <= location) {
+      line = entry.line_number;
+    } else {
+      break;
+    }
+  }
+  return info->source + ":" + std::to_string(line);
+}
+
+// ---------------------------------------------------------------------------
+// Sampling
+// ---------------------------------------------------------------------------
+
+struct Sample {
+  jthread thread;    // local ref, valid for this sampling round
+  std::string line;  // "" when out of scope
+};
+
+/// Take one sample of every Java thread's top frame.
+///
+/// `stack_info` is returned so the caller can free it only after it is done
+/// with the jthread refs inside.
+std::vector<Sample> take_sample(jvmtiStackInfo** stack_info) {
+  std::vector<Sample> samples;
+  jint thread_count = 0;
+  *stack_info = nullptr;
+
+  const int64_t sample_start = now_ns();
+  if (g_jvmti->GetAllStackTraces(1, stack_info, &thread_count) != JVMTI_ERROR_NONE) {
+    return samples;
+  }
+  g_ticks++;
+  g_sample_ns += now_ns() - sample_start;
+
+  JNIEnv* jni = nullptr;
+  g_vm->GetEnv(reinterpret_cast<void**>(&jni), JNI_VERSION_1_6);
+
+  for (jint i = 0; i < thread_count; i++) {
+    const jvmtiStackInfo& info = (*stack_info)[i];
+
+    // Never sample or suspend ourselves.
+    if (g_agent_thread != nullptr && jni != nullptr &&
+        jni->IsSameObject(info.thread, g_agent_thread)) {
+      continue;
+    }
+    if (info.frame_count < 1) continue;
+
+    Sample sample;
+    sample.thread = info.thread;
+    sample.line = resolve_line(info.frame_buffer[0].method, info.frame_buffer[0].location);
+    samples.push_back(std::move(sample));
+  }
+
+  return samples;
+}
+
+/// Suspend every thread that is not running `selected`, sleep for `delay_ns`,
+/// then resume them. This is the virtual speedup: the selected line appears
+/// faster because everything else stood still.
+///
+/// Returns the delay actually inserted, which the caller subtracts from the
+/// experiment's wall time. See the comment on `duration` in profiler_loop().
+int64_t insert_delay(const std::vector<Sample>& samples, const std::string& selected,
+                     int64_t delay_ns) {
+  if (delay_ns <= 0) return 0;
+
+  std::vector<jthread> victims;
+  victims.reserve(samples.size());
+  for (const Sample& sample : samples) {
+    if (sample.line != selected) victims.push_back(sample.thread);
+  }
+  if (victims.empty()) return 0;
+
+  std::vector<jvmtiError> results(victims.size());
+  if (g_jvmti->SuspendThreadList(static_cast<jint>(victims.size()), victims.data(),
+                                 results.data()) != JVMTI_ERROR_NONE) {
+    return 0;
+  }
+
+  const int64_t slept_start = now_ns();
+  sleep_ns(delay_ns);
+  const int64_t slept = now_ns() - slept_start;
+
+  // Resume only what actually suspended: a thread that died or was already
+  // suspended must not be resumed here.
+  std::vector<jthread> to_resume;
+  to_resume.reserve(victims.size());
+  for (size_t i = 0; i < victims.size(); i++) {
+    if (results[i] == JVMTI_ERROR_NONE) to_resume.push_back(victims[i]);
+  }
+  if (!to_resume.empty()) {
+    std::vector<jvmtiError> resume_results(to_resume.size());
+    g_jvmti->ResumeThreadList(static_cast<jint>(to_resume.size()), to_resume.data(),
+                              resume_results.data());
+  }
+
+  // The measured pause, not the requested one: sleep overshoots, and that
+  // overshoot is real time the program stood still.
+  return slept;
+}
+
+// ---------------------------------------------------------------------------
+// Experiments
+// ---------------------------------------------------------------------------
+
+struct Snapshot {
+  std::vector<std::pair<ProgressPoint*, int64_t>> counts;
+};
+
+Snapshot snapshot_points() {
+  Snapshot snap;
+  for (ProgressPoint* p = g_points.load(std::memory_order_acquire); p != nullptr; p = p->next) {
+    snap.counts.emplace_back(p, p->count.load(std::memory_order_relaxed));
+  }
+  return snap;
+}
+
+bool has_progress_point() { return g_points.load(std::memory_order_acquire) != nullptr; }
+
+/// Choose a line to speed up, weighted by how often it was sampled -- the same
+/// bias libcoz gets for free by selecting the line under the sampled PC.
+std::string select_line(const std::map<std::string, int64_t>& recent, std::mt19937_64& rng) {
+  int64_t total = 0;
+  for (const auto& entry : recent) total += entry.second;
+  if (total == 0) return "";
+
+  std::uniform_int_distribution<int64_t> pick(0, total - 1);
+  int64_t target = pick(rng);
+  for (const auto& entry : recent) {
+    if (target < entry.second) return entry.first;
+    target -= entry.second;
+  }
+  return recent.begin()->first;
+}
+
+void write_json_escaped(std::ostream& out, const std::string& value) {
+  for (char c : value) {
+    switch (c) {
+      case '"': out << "\\\""; break;
+      case '\\': out << "\\\\"; break;
+      case '\n': out << "\\n"; break;
+      case '\r': out << "\\r"; break;
+      case '\t': out << "\\t"; break;
+      default: out << c; break;
+    }
+  }
+}
+
+/// The profiler loop: warm up, then run experiments until the VM dies.
+void profiler_loop() {
+  std::ofstream out(g_options.output, std::ios::app);
+  if (!out) {
+    fprintf(stderr, "[coz-java] cannot open %s\n", g_options.output.c_str());
+    return;
+  }
+  out.setf(std::ios::fixed, std::ios::floatfield);
+  out.precision(2);
+
+  const int64_t start_time = now_ns();
+  out << "{\"type\":\"startup\",\"time\":" << start_time << "}\n" << std::flush;
+
+  std::mt19937_64 rng(static_cast<uint64_t>(start_time));
+  std::uniform_int_distribution<int> speedup_pick(0, kZeroSpeedupWeight + kSpeedupDivisions);
+
+  // Take one sample of every thread, folding it into `recent` (the pool the
+  // next line is drawn from) and into the lifetime totals.
+  //
+  // Every path that idles must call this. Otherwise `recent` -- which is
+  // cleared once a line has been drawn from it -- never refills, select_line()
+  // returns nothing forever, and the profiler quietly stops sampling.
+  auto collect = [&](std::map<std::string, int64_t>& recent) {
+    jvmtiStackInfo* stack_info = nullptr;
+    for (const Sample& sample : take_sample(&stack_info)) {
+      if (!sample.line.empty()) {
+        recent[sample.line]++;
+        g_samples[sample.line]++;
+      }
+    }
+    deallocate(stack_info);
+  };
+
+  // Idle for `duration`, sampling all the while.
+  auto idle = [&](std::map<std::string, int64_t>& recent, int64_t duration) {
+    const int64_t deadline = now_ns() + duration;
+    while (g_running.load(std::memory_order_relaxed) && now_ns() < deadline) {
+      collect(recent);
+      sleep_ns(g_options.sample_period);
+    }
+  };
+
+  // Wait for the program to register a progress point and for us to see a line
+  // worth speeding up.
+  std::map<std::string, int64_t> recent;
+  while (g_running.load(std::memory_order_relaxed) && (!has_progress_point() || recent.empty())) {
+    collect(recent);
+    sleep_ns(g_options.sample_period);
+  }
+
+  if (g_options.verbose && g_running.load(std::memory_order_relaxed)) {
+    fprintf(stderr, "[coz-java] warmed up: %zu lines, starting experiments\n", recent.size());
+  }
+
+  while (g_running.load(std::memory_order_relaxed)) {
+    const std::string selected = select_line(recent, rng);
+    recent.clear();
+    if (selected.empty()) {
+      // Nothing in scope has been sampled yet; keep looking.
+      collect(recent);
+      sleep_ns(g_options.sample_period);
+      continue;
+    }
+
+    // 0% is drawn with weight kZeroSpeedupWeight so the baseline is measured
+    // about half the time; the rest split the 5% increments.
+    const int draw = speedup_pick(rng);
+    const int division = (draw <= kZeroSpeedupWeight) ? 0 : draw - kZeroSpeedupWeight;
+    const double speedup = static_cast<double>(division) / kSpeedupDivisions;
+    const int64_t delay_per_sample =
+        static_cast<int64_t>(speedup * static_cast<double>(g_options.sample_period));
+
+    const Snapshot before = snapshot_points();
+    const int64_t experiment_start = now_ns();
+
+    int64_t selected_samples = 0;
+    int64_t batch_delay = 0;
+    int64_t inserted_delay = 0;
+    int batch = 0;
+
+    for (;;) {
+      if (!g_running.load(std::memory_order_relaxed)) break;
+
+      jvmtiStackInfo* stack_info = nullptr;
+      std::vector<Sample> samples = take_sample(&stack_info);
+
+      int64_t on_selected = 0;
+      for (const Sample& sample : samples) {
+        if (sample.line.empty()) continue;
+        recent[sample.line]++;
+        g_samples[sample.line]++;
+        if (sample.line == selected) on_selected++;
+      }
+      selected_samples += on_selected;
+      batch_delay += on_selected * delay_per_sample;
+
+      // Pay the accumulated debt once per batch, so the VM reaches a safepoint
+      // for delay insertion 10x less often than it does for sampling.
+      if (++batch >= kSampleBatchSize) {
+        inserted_delay += insert_delay(samples, selected, batch_delay);
+        batch_delay = 0;
+        batch = 0;
+      }
+
+      deallocate(stack_info);
+
+      const int64_t elapsed = now_ns() - experiment_start;
+      if (elapsed >= kExperimentMinTime) {
+        // Keep going until every progress point has moved enough to make the
+        // throughput estimate meaningful -- but never past kExperimentMaxTime.
+        int64_t min_delta = INT64_MAX;
+        for (const auto& entry : before.counts) {
+          const int64_t delta = entry.first->count.load(std::memory_order_relaxed) - entry.second;
+          if (delta < min_delta) min_delta = delta;
+        }
+        if (min_delta >= kExperimentTargetDelta || elapsed >= kExperimentMaxTime) break;
+      }
+
+      sleep_ns(g_options.sample_period);
+    }
+
+    // The virtual speedup is measured against the program's *effective* runtime,
+    // not its wall time. Pausing the other threads makes the run longer in real
+    // seconds while making the selected line relatively faster; the time we
+    // spent paused is not time the program was making progress, so it comes
+    // back out. libcoz does the same at profiler.cpp:362
+    //   duration = elapsed - experiment_delay
+    // Without this, period = duration/delta grows with the speedup and every
+    // line reports a negative slope.
+    const int64_t duration = (now_ns() - experiment_start) - inserted_delay;
+
+    // Only emit an experiment whose progress points actually advanced; a
+    // starved experiment would otherwise inflate the baseline period.
+    int64_t min_delta = INT64_MAX;
+    for (const auto& entry : before.counts) {
+      const int64_t delta = entry.first->count.load(std::memory_order_relaxed) - entry.second;
+      if (delta < min_delta) min_delta = delta;
+    }
+    if (min_delta == INT64_MAX || min_delta < kExperimentTargetDelta) {
+      // A starved experiment tells us nothing, and emitting it would drag the
+      // aggregated baseline period around. Drop it, but keep sampling so the
+      // next round has a line to pick.
+      idle(recent, kExperimentCoolOff);
+      continue;
+    }
+
+    out << "{\"type\":\"experiment\",\"selected\":\"";
+    write_json_escaped(out, selected);
+    out << "\",\"speedup\":" << speedup << ",\"duration\":" << duration
+        << ",\"selected_samples\":" << selected_samples << "}\n";
+
+    // Each experiment record is immediately followed by the delta for every
+    // progress point, which is the format `coz plot` expects.
+    for (const auto& entry : before.counts) {
+      ProgressPoint* point = entry.first;
+      const int64_t delta = point->count.load(std::memory_order_relaxed) - entry.second;
+      const char* kind = (point->kind == kThroughput) ? "throughput-point" : "latency-point";
+      out << "{\"type\":\"" << kind << "\",\"name\":\"";
+      write_json_escaped(out, point->name);
+      out << "\",\"delta\":" << delta << "}\n";
+    }
+    out << std::flush;
+
+    idle(recent, kExperimentCoolOff);
+  }
+
+  for (const auto& entry : g_samples) {
+    out << "{\"type\":\"samples\",\"location\":\"";
+    write_json_escaped(out, entry.first);
+    out << "\",\"count\":" << entry.second << "}\n";
+  }
+  out << "{\"type\":\"runtime\",\"time\":" << (now_ns() - start_time) << "}\n";
+  out.flush();
+
+  if (g_options.verbose) {
+    fprintf(stderr,
+            "[coz-java] wrote %s (%lld sample ticks, mean GetAllStackTraces %lld us)\n",
+            g_options.output.c_str(), static_cast<long long>(g_ticks),
+            static_cast<long long>(g_ticks ? g_sample_ns / g_ticks / 1000 : 0));
+  }
+}
+
+void JNICALL sampler_entry(jvmtiEnv*, JNIEnv*, void*) { profiler_loop(); }
+
+// ---------------------------------------------------------------------------
+// Natives behind coz.Coz
+// ---------------------------------------------------------------------------
+
+jboolean JNICALL Coz_available(JNIEnv*, jclass) { return JNI_TRUE; }
+
+void bump(JNIEnv* jni, jstring name, CounterKind kind) {
+  if (name == nullptr) return;
+  const char* chars = jni->GetStringUTFChars(name, nullptr);
+  if (chars == nullptr) return;
+  find_or_create(chars, kind)->count.fetch_add(1, std::memory_order_relaxed);
+  jni->ReleaseStringUTFChars(name, chars);
+}
+
+void JNICALL Coz_progress(JNIEnv* jni, jclass, jstring name) { bump(jni, name, kThroughput); }
+void JNICALL Coz_begin(JNIEnv* jni, jclass, jstring name) { bump(jni, name, kBegin); }
+void JNICALL Coz_end(JNIEnv* jni, jclass, jstring name) { bump(jni, name, kEnd); }
+
+// ---------------------------------------------------------------------------
+// Agent lifecycle
+// ---------------------------------------------------------------------------
+
+void parse_options(const char* options) {
+  if (options == nullptr) return;
+
+  std::string rest(options);
+  while (!rest.empty()) {
+    const size_t comma = rest.find(',');
+    std::string item = rest.substr(0, comma);
+    rest = (comma == std::string::npos) ? "" : rest.substr(comma + 1);
+
+    const size_t eq = item.find('=');
+    if (eq == std::string::npos) continue;
+    const std::string key = item.substr(0, eq);
+    const std::string value = item.substr(eq + 1);
+
+    if (key == "output") {
+      g_options.output = value;
+    } else if (key == "scope") {
+      g_options.scope = value;
+      // Accept dotted package names; JVMTI signatures are slash-separated.
+      for (char& c : g_options.scope) {
+        if (c == '.') c = '/';
+      }
+    } else if (key == "period") {
+      g_options.sample_period = std::strtoll(value.c_str(), nullptr, 10);
+    } else if (key == "verbose") {
+      g_options.verbose = (value != "0");
+    }
+  }
+}
+
+jthread alloc_agent_thread(JNIEnv* jni) {
+  jclass thread_class = jni->FindClass("java/lang/Thread");
+  jmethodID ctor = jni->GetMethodID(thread_class, "<init>", "(Ljava/lang/String;)V");
+  jstring name = jni->NewStringUTF("coz-profiler");
+  jthread thread = static_cast<jthread>(jni->NewObject(thread_class, ctor, name));
+  return static_cast<jthread>(jni->NewGlobalRef(thread));
+}
+
+void JNICALL on_vm_init(jvmtiEnv* jvmti, JNIEnv* jni, jthread) {
+  jclass coz = jni->FindClass("coz/Coz");
+  if (coz == nullptr) {
+    // The application never loaded coz.Coz. Sampling would still work, but
+    // with no progress point there is nothing to correlate a speedup against.
+    jni->ExceptionClear();
+    fprintf(stderr,
+            "[coz-java] coz.Coz not found on the classpath; no progress points, "
+            "no profile will be written\n");
+    return;
+  }
+
+  static const JNINativeMethod natives[] = {
+      {const_cast<char*>("available0"), const_cast<char*>("()Z"),
+       reinterpret_cast<void*>(Coz_available)},
+      {const_cast<char*>("progress0"), const_cast<char*>("(Ljava/lang/String;)V"),
+       reinterpret_cast<void*>(Coz_progress)},
+      {const_cast<char*>("begin0"), const_cast<char*>("(Ljava/lang/String;)V"),
+       reinterpret_cast<void*>(Coz_begin)},
+      {const_cast<char*>("end0"), const_cast<char*>("(Ljava/lang/String;)V"),
+       reinterpret_cast<void*>(Coz_end)},
+  };
+
+  if (jni->RegisterNatives(coz, natives, 4) != 0) {
+    fprintf(stderr, "[coz-java] failed to register natives on coz.Coz\n");
+    return;
+  }
+
+  g_agent_thread = alloc_agent_thread(jni);
+  g_running.store(true, std::memory_order_relaxed);
+  jvmti->RunAgentThread(g_agent_thread, &sampler_entry, nullptr, JVMTI_THREAD_NORM_PRIORITY);
+
+  if (g_options.verbose) {
+    fprintf(stderr, "[coz-java] agent started (output=%s, scope=%s, period=%lldns)\n",
+            g_options.output.c_str(), g_options.scope.empty() ? "<application>" : g_options.scope.c_str(),
+            static_cast<long long>(g_options.sample_period));
+  }
+}
+
+void JNICALL on_vm_death(jvmtiEnv*, JNIEnv*) {
+  // Let the profiler loop notice, finish its current experiment, and flush.
+  g_running.store(false, std::memory_order_relaxed);
+  // The agent thread sleeps at most one sample period between checks, plus the
+  // time to write its summary records.
+  sleep_ns(g_options.sample_period * 4);
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* vm, char* options, void*) {
+  g_vm = vm;
+  parse_options(options);
+
+  if (vm->GetEnv(reinterpret_cast<void**>(&g_jvmti), JVMTI_VERSION_1_2) != JNI_OK) {
+    fprintf(stderr, "[coz-java] this JVM does not support JVMTI 1.2\n");
+    return JNI_ERR;
+  }
+
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_suspend = 1;                 // insert virtual delays
+  caps.can_get_line_numbers = 1;        // map bytecode index to source line
+  caps.can_get_source_file_name = 1;    // name the source file
+  if (g_jvmti->AddCapabilities(&caps) != JVMTI_ERROR_NONE) {
+    fprintf(stderr, "[coz-java] JVM denied the capabilities coz needs\n");
+    return JNI_ERR;
+  }
+
+  jvmtiEventCallbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.VMInit = &on_vm_init;
+  callbacks.VMDeath = &on_vm_death;
+  if (g_jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks)) != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+
+  g_jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, nullptr);
+  g_jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, nullptr);
+  return JNI_OK;
+}
+
+extern "C" JNIEXPORT void JNICALL Agent_OnUnload(JavaVM*) {
+  g_running.store(false, std::memory_order_relaxed);
+}

--- a/java/example/Toy.java
+++ b/java/example/Toy.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+package example;
+
+import coz.Coz;
+
+/**
+ * The Java port of benchmarks/toy: two threads do unequal amounts of work, and a progress point
+ * marks each completed round.
+ *
+ * <p>slowWork does twice the work of fastWork, so it sits on the critical path. A correct causal
+ * profile predicts a large speedup for the loop inside slowWork and almost none for the one inside
+ * fastWork.
+ */
+public final class Toy {
+
+    /**
+     * An {@code int} counter, not a {@code long}, on purpose.
+     *
+     * <p>HotSpot strip-mines int counted loops and leaves a safepoint poll in the outer strip, so
+     * the VM can reach a safepoint mid-loop. A long counted loop gets no poll here, and the coz
+     * agent's GetAllStackTraces then blocks until the loop *finishes* -- time-to-safepoint of ~76ms,
+     * which collapses the sample rate and pins every sample to the line after the loop.
+     */
+    private static final int ITERATIONS = 60_000_000;
+
+    /** Written by the workers so the JIT cannot delete their loops. */
+    static volatile long slowSink;
+    static volatile long fastSink;
+
+    private Toy() {}
+
+    private static long xorshift(long value) {
+        value ^= value << 13;
+        value ^= value >>> 7;
+        value ^= value << 17;
+        return value;
+    }
+
+    static void slowWork() {
+        long acc = 0x9E3779B97F4A7C15L;
+        for (int i = 0; i < ITERATIONS; i++) {
+            acc = xorshift(acc);
+        }
+        slowSink = acc;
+    }
+
+    static void fastWork() {
+        long acc = 0x9E3779B97F4A7C15L;
+        for (int i = 0; i < ITERATIONS / 2; i++) {
+            acc = xorshift(acc);
+        }
+        fastSink = acc;
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("Starting. coz agent attached: " + Coz.isAvailable());
+
+        for (int round = 0; round < 100; round++) {
+            Thread slow = new Thread(Toy::slowWork, "slow");
+            Thread fast = new Thread(Toy::fastWork, "fast");
+            slow.start();
+            fast.start();
+            slow.join();
+            fast.join();
+
+            // One round of work finished: this is the throughput progress point.
+            Coz.progress("round");
+
+            System.out.print(".");
+            System.out.flush();
+        }
+
+        System.out.println("\nDone. " + slowSink + " " + fastSink);
+    }
+}

--- a/java/src/coz/Coz.java
+++ b/java/src/coz/Coz.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2015, Charlie Curtsinger and Emery Berger,
+ *                     University of Massachusetts Amherst
+ * This file is part of the Coz project. See LICENSE.md file at the top-level
+ * directory of this distribution and at http://github.com/plasma-umass/coz.
+ */
+
+package coz;
+
+/**
+ * Progress points for the coz causal profiler.
+ *
+ * <p>Coz answers "if I optimize this line, will the program actually get faster?" Mark the points
+ * where your program makes progress, then run it under the coz JVMTI agent:
+ *
+ * <pre>
+ *   javac -g -d classes MyApp.java
+ *   java -agentpath:/path/to/libcozjava.so=output=profile.jsonl,scope=com.example \
+ *        -cp classes:coz.jar com.example.MyApp
+ *   coz plot --text -i profile.jsonl
+ * </pre>
+ *
+ * <p>When the agent is not loaded every method here is a no-op, so instrumented code runs
+ * normally outside profiling.
+ *
+ * <p>All methods are safe to call from any thread.
+ */
+public final class Coz {
+
+    /**
+     * Whether the coz agent is attached.
+     *
+     * <p>Deliberately in a holder class rather than a static field of {@code Coz}. The agent binds
+     * the natives below with RegisterNatives during VM init, and to find this class it calls JNI
+     * FindClass -- which *initializes* it. A {@code static final boolean ENABLED = probe()} on
+     * {@code Coz} would therefore run before the natives were bound, see UnsatisfiedLinkError, and
+     * latch "not profiling" for the life of the VM.
+     *
+     * <p>The holder is only initialized on first use from application code, which is necessarily
+     * after VM init, so by then the natives are bound.
+     */
+    private static final class Enabled {
+        static final boolean VALUE = probe();
+
+        private static boolean probe() {
+            try {
+                return available0();
+            } catch (UnsatisfiedLinkError e) {
+                return false;
+            }
+        }
+    }
+
+    private Coz() {}
+
+    /** Whether this JVM is running under the coz agent. */
+    public static boolean isAvailable() {
+        return Enabled.VALUE;
+    }
+
+    /**
+     * Records a visit to the named throughput progress point: "I wish this happened more often."
+     * The equivalent of {@code COZ_PROGRESS_NAMED}.
+     */
+    public static void progress(String name) {
+        if (Enabled.VALUE) {
+            progress0(name);
+        }
+    }
+
+    /**
+     * Records a visit to a throughput progress point named after the calling class, method and
+     * line. The equivalent of {@code COZ_PROGRESS}.
+     *
+     * <p>Determining the call site walks one stack frame. On a hot path, prefer
+     * {@link #progress(String)}.
+     */
+    public static void progress() {
+        if (Enabled.VALUE) {
+            progress0(callSite());
+        }
+    }
+
+    /**
+     * Marks the start of a latency-profiled operation: "I wish this finished sooner." The
+     * equivalent of {@code COZ_BEGIN}. Must be paired with {@link #end(String)}.
+     */
+    public static void begin(String name) {
+        if (Enabled.VALUE) {
+            begin0(name);
+        }
+    }
+
+    /**
+     * Marks the completion of a latency-profiled operation, the equivalent of {@code COZ_END}.
+     * Must be paired with {@link #begin(String)}.
+     */
+    public static void end(String name) {
+        if (Enabled.VALUE) {
+            end0(name);
+        }
+    }
+
+    /**
+     * Runs {@code body} bracketed by {@link #begin(String)} and {@link #end(String)}, so the end
+     * counter fires even if the body throws.
+     *
+     * <pre>
+     *   Coz.scope("request", () -&gt; handle(request));
+     * </pre>
+     */
+    public static void scope(String name, Runnable body) {
+        begin(name);
+        try {
+            body.run();
+        } finally {
+            end(name);
+        }
+    }
+
+    /** Renders the caller of {@code progress()} as "Class.method:line". */
+    private static String callSite() {
+        return StackWalker.getInstance()
+                .walk(frames -> frames
+                        .skip(2) // callSite, progress
+                        .findFirst()
+                        .map(f -> f.getClassName() + "." + f.getMethodName() + ":" + f.getLineNumber())
+                        .orElse("unknown"));
+    }
+
+    // Bound by the agent's RegisterNatives at VM init.
+    private static native boolean available0();
+
+    private static native void progress0(String name);
+
+    private static native void begin0(String name);
+
+    private static native void end0(String name);
+}


### PR DESCRIPTION
Java is the one language here that cannot be a thin binding.

Rust, Go and Swift hand their progress points to `libcoz`, which samples the PC, maps it to a source line through DWARF, and inserts virtual delays by pausing native threads. On the JVM none of that holds: JIT-compiled methods live in anonymous memory with **no DWARF**, so a sampled PC maps to nothing, and the threads to delay are Java threads `libcoz` has never heard of.

So Java gets a real JVMTI agent that reimplements the causal profiling loop in JVM terms, and emits coz's own JSON Lines profile so **`coz plot` reads it unchanged**.

## Design

| | this agent | [JCoz](https://github.com/Decave/JCoz) |
|---|---|---|
| stack sampling | `GetAllStackTraces` (documented JVMTI) | `AsyncGetCallTrace` (private, undocumented HotSpot) |
| progress points | `coz.Coz.progress()` in source | JVMTI breakpoints set over JMX/RMI |
| client | none | separate RMI/CLI process, needs `tools.jar` (removed in JDK 9) |
| agent load | static `-agentpath` ([JEP 451](https://openjdk.org/jeps/451) N/A) | static, but control path uses dynamic attach |
| macOS | yes | Linux/x86 only |

Virtual speedup is real, not simulated: for each sample on the selected line the agent owes every *other* thread a pause of `speedup × sample_period`, paid with `SuspendThreadList`/`ResumeThreadList` and batched so the VM reaches a safepoint once per batch rather than once per sample.

**No lock is ever shared with a Java thread.** The agent suspends threads at arbitrary points; if a suspended thread held a lock the agent then wanted, it would deadlock the VM. The progress-point registry is an append-only lock-free list, and everything else is touched by the agent thread alone.

## Three bugs worth calling out

1. **`coz.Coz` keeps its "agent attached" flag in a holder class.** The agent locates the class with JNI `FindClass`, which *initializes* it — before `RegisterNatives` has bound the natives. A plain `static final boolean ENABLED = probe()` on `Coz` therefore ran first, caught `UnsatisfiedLinkError`, and latched "not profiling" for the life of the VM. Symptom: `coz agent attached: false` with the agent demonstrably loaded.

2. **Idle paths must keep sampling.** `recent` — the pool the next line is drawn from — is cleared once a line has been drawn. Any path that slept without sampling left it empty, so `select_line()` returned nothing forever and the profiler silently stopped sampling.

3. **Experiment duration is wall time *minus the inserted delay*.** This is what `libcoz` does at `profiler.cpp:362` (`duration = elapsed - experiment_delay`). Pausing the other threads makes the run longer in real seconds while making the selected line relatively faster; the paused time is not progress. Reporting raw wall clock made `period = duration/delta` grow with the speedup and gave **every line a negative slope** (−0.514 on the toy).

## Verification

`java/example/Toy.java`: two threads per round, `slowWork` does twice the work of `fastWork`.

**macOS arm64 (Temurin 17)** — 18 experiments, stable over 3 runs:
```
example/Toy.java:47 |   0.496 |  1.00 | +     41.3%    <- slowWork's loop
example/Toy.java:55 |   0.090 |  0.21 | +     14.1%    <- fastWork's loop
```

**Linux aarch64 (OpenJDK/Temurin 21)** — 19 experiments, both runs:
```
example/Toy.java:47 |   0.396 |  0.90 | +     40.6%
example/Toy.java:55 |   0.007 |  0.02 | +      2.3%
```

Sampling lands 1666 vs 944 on the two loops — a 1.77:1 ratio against their 2:1 work ratio.

## The GraalVM caveat (documented, and CI pins around it)

The agent samples at safepoints, so its sample rate is bounded by time-to-safepoint. Measured on the same toy:

| JIT | mean `GetAllStackTraces` | sample ticks |
|---|---|---|
| HotSpot C2 | **147 µs** | 1671 |
| GraalVM JIT | **103,862 µs** | 105 |

Graal left no safepoint poll in the hot counted loop, so the agent sampled ~10×/second and could attribute nothing. Use a HotSpot JDK, or `-XX:-UseJVMCICompiler` on GraalVM. `verbose=1` prints the number so users can check; `java/README.md` says "if that number is in the milliseconds, your profile is not trustworthy."

This is also why the CI job pins `distribution: temurin`.

## Contents

- `java/agent/coz_agent.cpp` — the agent
- `java/src/coz/Coz.java` — `progress` / `begin` / `end` / `scope` / `isAvailable`; all no-ops without the agent
- `java/example/Toy.java`, `java/README.md`, `java/CMakeLists.txt`
- `-DBUILD_JAVA_AGENT=ON` (off by default; needs a JDK)
- CI job `lang-java` on Linux + macOS, asserting experiments are attributed to `Toy.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)