### PR TITLE
Compute the load bias with dl_iterate_phdr, not base - offset

### DIFF
--- a/libcoz/inspect.cpp
+++ b/libcoz/inspect.cpp
@@ -5,6 +5,12 @@
  * directory of this distribution and at http://github.com/plasma-umass/coz.
  */
 
+#ifndef __APPLE__
+#include <link.h>
+#include <limits.h>
+#include <unistd.h>
+#endif
+
 #include "inspect.h"
 
 #include "lief_loader.h"
@@ -119,47 +125,57 @@ unordered_map<string, uintptr_t> get_loaded_files() {
   return result;
 }
 #else
-unordered_map<string, uintptr_t> get_loaded_files() {
-  unordered_map<string, uintptr_t> result;
+/// Resolve the main executable's path, since dl_iterate_phdr reports it as "".
+static string main_executable_path() {
+  char buffer[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+  if(len <= 0) return string();
+  buffer[len] = '\0';
+  return string(buffer);
+}
 
-  ifstream maps("/proc/self/maps");
-  while(maps.good() && !maps.eof()) {
-    uintptr_t base, limit;
-    char perms[5];
-    size_t offset;
-    size_t dev_major, dev_minor;
-    uintptr_t inode;
-    string path;
+static int collect_loaded_file(struct dl_phdr_info* info, size_t, void* data) {
+  auto* result = static_cast<unordered_map<string, uintptr_t>*>(data);
 
-    // Skip over whitespace
-    maps >> skipws;
+  string path = (info->dlpi_name != nullptr && info->dlpi_name[0] != '\0')
+                    ? string(info->dlpi_name)
+                    : main_executable_path();
 
-    // Read in "<base>-<limit> <perms> <offset> <dev_major>:<dev_minor> <inode>"
-    maps >> std::hex >> base;
-    if(maps.get() != '-') break;
-    maps >> std::hex >> limit;
+  // The vDSO and other synthetic objects have no file to read DWARF from.
+  if(path.empty() || path[0] != '/') return 0;
 
-    if(maps.get() != ' ') break;
-    maps.get(perms, 5);
-
-    maps >> std::hex >> offset;
-    maps >> std::hex >> dev_major;
-    if(maps.get() != ':') break;
-    maps >> std::hex >> dev_minor;
-    maps >> std::dec >> inode;
-
-    // Skip over spaces and tabs
-    while(maps.peek() == ' ' || maps.peek() == '\t') { maps.ignore(1); }
-
-    // Read out the mapped file's path
-    getline(maps, path);
-
-    // If this is an executable mapping of an absolute path, include it
-    if(perms[2] == 'x' && path[0] == '/') {
-      result[path] = base - offset;
+  // Only objects with executable code can contain a sampled program counter.
+  bool has_executable_segment = false;
+  for(int i = 0; i < info->dlpi_phnum; i++) {
+    const ElfW(Phdr)& phdr = info->dlpi_phdr[i];
+    if(phdr.p_type == PT_LOAD && (phdr.p_flags & PF_X)) {
+      has_executable_segment = true;
+      break;
     }
   }
+  if(!has_executable_segment) return 0;
 
+  // dlpi_addr *is* the load bias: the value to add to a virtual address from
+  // the object's headers to get the address it actually lives at.
+  (*result)[path] = static_cast<uintptr_t>(info->dlpi_addr);
+  return 0;
+}
+
+/// Map each loaded object's path to its load bias.
+///
+/// This used to parse /proc/self/maps and take `base - offset` of the first
+/// executable mapping. That only equals the load bias when the executable
+/// PT_LOAD segment satisfies p_vaddr == p_offset. It usually does for a simple
+/// C program, so the bug hid for years -- but rustc's output has, for example,
+/// p_offset=0x14f80 against p_vaddr=0x15f80, and the bias came out 0x1000 too
+/// large. Every line range was then shifted by a page: most samples still landed
+/// inside *some* line, so coz reported plausible-looking profiles attributed to
+/// the wrong source lines, and on some layouts nothing matched at all.
+///
+/// dl_iterate_phdr reports the bias directly, which is what it is for.
+unordered_map<string, uintptr_t> get_loaded_files() {
+  unordered_map<string, uintptr_t> result;
+  dl_iterate_phdr(collect_loaded_file, &result);
   return result;
 }
 #endif


### PR DESCRIPTION
`get_loaded_files()` parsed `/proc/self/maps` and took **`base - offset`** of each executable mapping as that object's load bias. That is only the bias when the executable `PT_LOAD` segment satisfies `p_vaddr == p_offset`.

It usually does for a simple C program, so the bug hid. It does not for rustc's output:

| binary | exec `PT_LOAD` | `vaddr - offset` |
|---|---|---|
| `benchmarks/toy` (g++) | `off=0x1000 vaddr=0x1000` | 0 ✓ |
| `rust/examples/toy` | `off=0x14f80 vaddr=0x15f80` | **0x1000** ✗ |

So the computed bias was a page too large, and every line range was shifted by 4 KB.

## Why this is worse than a crash

Nothing looks wrong. Most samples still land inside *some* line, so coz produces a confident, plausible profile — attributed to the wrong source lines. Measured on x86_64 with the Rust toy:

| | samples matched | hottest line reported |
|---|---|---|
| before | 39049 / 43506 (89.8%) | `rust/examples/toy.rs:5` — the `thread::spawn` call |
| after | 43492 / 43513 (99.95%) | `rust/src/lib.rs:164` — the atomic increment |

Line 5 is where the toy *spawns* its threads and burns no time. Line 164 is the counter increment it runs 4.4e9 times. The old answer was not noise; it was a specific, wrong, believable answer.

On some layouts the shift lands outside every range and nothing matches. **That is what CI was hitting**: the Rust toy produced 10242 perf samples and matched **zero**, while the C toy in the same job matched 23300 / 23300. I chased that from an empty profile → `sigprof=1023, samples=10242, matched=0` → the program headers.

## Fix

`dl_iterate_phdr` reports `dlpi_addr`, which *is* the bias, for the main executable and every shared object — no header arithmetic, no maps parsing. The main executable comes back with an empty `dlpi_name`, so it's resolved via `/proc/self/exe`. Objects without an executable `PT_LOAD` can't contain a sampled PC and are skipped, as are synthetic ones (vDSO) with no file to read DWARF from.

## Verification (x86_64 Ubuntu, real hardware)

- Rust toy: 89.8% → 99.95% of samples matched, attribution moves to the line that actually runs.
- `benchmarks/toy`: 107488 / 107525 matched, `toy.cpp:18` slope 0.504 — unchanged.
- macOS is untouched; it has its own `get_loaded_files()` built on dyld.

This should also turn the `Rust bindings (ubuntu-latest)` job in #286 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)