### PR TITLE
fix: replace bare except with specific exception types in line_ref()

### DIFF
--- a/coz
+++ b/coz
@@ -2272,7 +2272,7 @@ def line_ref(val):
     (filename, line) = val.rsplit(':', 1)
     line = int(line)
     return filename + ':' + str(line)
-  except:
+  except (ValueError, TypeError):
     msg = "Invalid line reference %r. The format is <source file>:<line number>." % val
     raise argparse.ArgumentTypeError(msg)
 


### PR DESCRIPTION
The `line_ref()` function uses a bare `except:` clause to catch errors when parsing a `filename:line` argument. Bare `except:` catches all exceptions including `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`, which is broader than intended.

The only exceptions that can realistically occur here are:
- `ValueError` when the string has no `:" and unpacking fails (rsplit returns a 1-element list)
- `ValueError` when the part after `:` is not a valid integer (from `int(line)`)
- `TypeError` if `val` is not a string

Replace with `except (ValueError, TypeError):` to be more specific about what errors are expected.